### PR TITLE
Stabilize format-messages editorial fallback test

### DIFF
--- a/src/adapters/n8n/format-messages.adapter.test.ts
+++ b/src/adapters/n8n/format-messages.adapter.test.ts
@@ -789,6 +789,15 @@ describe('run — weekStandout validation', () => {
             sunsetStr: '18:11',
             moonPct: 8,
             metarNote: '',
+            debugContext: {
+              metadata: {
+                generatedAt: '2026-03-16T12:00:00.000Z',
+                timezone: 'Europe/London',
+              },
+              hourlyScoring: [],
+              windows: [],
+              nearbyAlternatives: [],
+            },
             today: 'Monday 16 March',
             todayBestScore: 60,
             shSunsetQ: null,
@@ -920,6 +929,15 @@ describe('run — weekStandout validation', () => {
               tmp: 8,
             },
             altLocations: [],
+            debugContext: {
+              metadata: {
+                generatedAt: '2026-03-16T12:00:00.000Z',
+                timezone: 'Europe/London',
+              },
+              hourlyScoring: [],
+              windows: [],
+              nearbyAlternatives: [],
+            },
             sunriseStr: '06:18',
             sunsetStr: '18:11',
             moonPct: 8,


### PR DESCRIPTION
## Summary
- pin the runtime debug context in the week-standout formatter fixtures so the local window stays in the intended time state
- remove the leftover diagnostic probe from the failing editorial fallback spec
- keep the spec focused on editorial fallback instead of the separate all-past time-aware fallback path

Closes #60

## Testing
- npm test -- src/adapters/n8n/format-messages.adapter.test.ts