### PR TITLE
Update session trace expectation after session merges

### DIFF
--- a/src/core/score-hours.test.ts
+++ b/src/core/score-hours.test.ts
@@ -570,7 +570,14 @@ describe('scoreAllDays session scoring foundation', () => {
     const result = scoreAllDays(input, new Date('2026-03-27T12:00:00Z'));
 
     expect(result.debugContext.hourlyScoring).toHaveLength(2);
-    expect(result.debugContext.hourlyScoring[0]?.sessionScores?.map(score => score.session)).toEqual(['astro', 'mist', 'urban', 'golden-hour', 'storm']);
+    expect(result.debugContext.hourlyScoring[0]?.sessionScores?.map(score => score.session)).toEqual([
+      'long-exposure',
+      'astro',
+      'mist',
+      'urban',
+      'golden-hour',
+      'storm',
+    ]);
     expect(result.debugContext.hourlyScoring[1]?.sessionScores?.some(score => score.session === 'mist')).toBe(true);
     expect(result.debugContext.scores?.bestSession).toBeDefined();
     expect(result.sessionRecommendation.primary).toBeDefined();


### PR DESCRIPTION
## Summary
- update the score-hours debug trace expectation to include the merged `long-exposure` session
- keep downstream test coverage aligned with the expanded built-in session ranking

Closes #64

## Testing
- npm test -- src/core/session-scoring.test.ts src/core/score-hours.test.ts