### PR TITLE
fix: AI editorial pipeline reliability and debug diagnostics

### DIFF
--- a/src/core/ai-briefing.ts
+++ b/src/core/ai-briefing.ts
@@ -241,6 +241,19 @@ export function buildFallbackAiText(ctx: AiBriefingContext): string {
     return `${firstSentence} If you miss it, ${nextWindow.label.toLowerCase()} is the later fallback from ${windowRange(nextWindow)}.`;
   }
 
+  if (topAlt?.name && typeof topAlt.bestScore === 'number' && topAlt.bestScore > (topWindow.peak ?? 0)) {
+    const altDrive = topAlt.driveMins ? ` (${topAlt.driveMins}-minute drive)` : '';
+    return `${firstSentence} ${topAlt.name} scores higher at ${topAlt.bestScore}/100 if you can make the trip${altDrive}.`;
+  }
+
+  if (typeof topWindow.peak === 'number' && topWindow.peak >= 75) {
+    return `${firstSentence} Conditions look strong — worth getting out for.`;
+  }
+
+  if (typeof topWindow.peak === 'number' && topWindow.peak < 42) {
+    return `${firstSentence} Marginal conditions overall, so keep expectations modest.`;
+  }
+
   return firstSentence;
 }
 

--- a/src/core/format-email/debug-email.ts
+++ b/src/core/format-email/debug-email.ts
@@ -266,7 +266,22 @@ export function formatDebugEmail(debugContext: DebugContext): string {
           const windowLine = outdoorComfort.bestWindow
             ? `<div style="Margin-top:8px;font-family:${FONT};font-size:12px;line-height:1.5;color:${C.ink};"><span style="font-weight:700;color:${C.onPrimaryContainer};">Best window:</span> ${esc(outdoorComfort.bestWindow.start)}–${esc(outdoorComfort.bestWindow.end)} (${esc(outdoorComfort.bestWindow.label)})</div>`
             : `<div style="Margin-top:8px;font-family:${FONT};font-size:12px;line-height:1.5;color:${C.muted};">No highlighted outdoor window found.</div>`;
-          return `${spacer(8)}${debugCard('Outdoor comfort window trace', `${debugTable(['Hour', 'Temp', 'Rain', 'Wind', 'Vis', 'Precip', 'Score', 'Label'], outdoorRows)}${windowLine}`)}`;
+          const driftWarnings: string[] = [];
+          const scoringByHour = new Map(debugContext.hourlyScoring.map(h => [h.hour, h]));
+          for (const hour of outdoorComfort.hours) {
+            const scoring = scoringByHour.get(hour.hour);
+            if (!scoring) continue;
+            if (Math.abs(scoring.visK - hour.visK) > 1) {
+              driftWarnings.push(`${hour.hour}: vis ${scoring.visK}km (scoring) vs ${hour.visK}km (outdoor)`);
+            }
+            if (Math.abs(scoring.cloud - hour.pp) > 5) {
+              driftWarnings.push(`${hour.hour}: cloud ${scoring.cloud}% (scoring) vs rain ${hour.pp}% (outdoor)`);
+            }
+          }
+          const driftLine = driftWarnings.length
+            ? `<div style="Margin-top:8px;padding:8px;background:#FFF3CD;border:1px solid #FFECB5;border-radius:6px;font-family:${FONT};font-size:11px;line-height:1.5;color:#664D03;">⚠ Data drift detected between scoring trace and outdoor comfort source:<br>${driftWarnings.map(w => esc(w)).join('<br>')}</div>`
+            : '';
+          return `${spacer(8)}${debugCard('Outdoor comfort window trace', `${debugTable(['Hour', 'Temp', 'Rain', 'Wind', 'Vis', 'Precip', 'Score', 'Label'], outdoorRows)}${windowLine}${driftLine}`)}`;
         })()}
       </td>
     </tr>

--- a/src/editorial/resolve-editorial.ts
+++ b/src/editorial/resolve-editorial.ts
@@ -498,7 +498,7 @@ function buildEditorialCandidate(
     factualCheck,
     editorialCheck,
     passed: factualCheck.passed && editorialCheck.passed,
-    reusableComponents: factualCheck.passed,
+    reusableComponents: parsed.weekStandoutParseStatus !== 'parse-failure',
   };
 }
 
@@ -917,16 +917,30 @@ export function resolveEditorial(input: ResolveEditorialInput): ResolveEditorial
     || componentCandidate
     || editorialChoice.primaryCandidate
     || editorialChoice.secondaryCandidate;
+  const bestSpurRaw = componentCandidate?.spurRaw
+    || editorialChoice.primaryCandidate?.spurRaw
+    || editorialChoice.secondaryCandidate?.spurRaw
+    || null;
   const spurOfTheMoment = resolveSpurSuggestion(
-    componentCandidate?.spurRaw || null,
+    bestSpurRaw,
     nearbyAltNames,
     longRangePool,
   );
   const aiText = editorialCandidate
     ? editorialCandidate.normalizedAiText
     : buildFallbackAiText(ctx);
-  const resolvedWeekStandout = validateWeekInsight(componentCandidate?.weekInsight || '', ctx.dailySummary);
-  const safeCompositionBullets = filterCompositionBullets(componentCandidate?.compositionBullets || [], ctx);
+  const bestWeekInsight = (componentCandidate?.weekInsight || '')
+    || editorialChoice.primaryCandidate?.weekInsight
+    || editorialChoice.secondaryCandidate?.weekInsight
+    || '';
+  const resolvedWeekStandout = validateWeekInsight(bestWeekInsight, ctx.dailySummary);
+  const safeCompositionBullets = filterCompositionBullets(
+    (componentCandidate?.compositionBullets?.length ? componentCandidate.compositionBullets : null)
+      || editorialChoice.primaryCandidate?.compositionBullets
+      || editorialChoice.secondaryCandidate?.compositionBullets
+      || [],
+    ctx,
+  );
   const safeGeminiInspire = typeof geminiInspire === 'string' && geminiInspire.trim().length > 0
     ? geminiInspire.trim()
     : undefined;
@@ -976,11 +990,11 @@ export function resolveEditorial(input: ResolveEditorialInput): ResolveEditorial
       factualCheck: traceCandidate?.factualCheck || { passed: false, rulesTriggered: ['missing AI summary'] },
       editorialCheck: traceCandidate?.editorialCheck || { passed: false, rulesTriggered: ['missing AI summary'] },
       spurSuggestion: {
-        raw: componentCandidate?.spurRaw ? `${componentCandidate.spurRaw.locationName} (${componentCandidate.spurRaw.confidence})` : null,
-        confidence: componentCandidate?.spurRaw?.confidence ?? null,
+        raw: bestSpurRaw ? `${bestSpurRaw.locationName} (${bestSpurRaw.confidence})` : null,
+        confidence: bestSpurRaw?.confidence ?? null,
         resolved: spurOfTheMoment?.locationName || null,
-        dropped: Boolean(componentCandidate?.spurRaw) && !spurOfTheMoment,
-        dropReason: resolveSpurDropReason(componentCandidate?.spurRaw || null, nearbyAltNames, longRangePool),
+        dropped: Boolean(bestSpurRaw) && !spurOfTheMoment,
+        dropReason: resolveSpurDropReason(bestSpurRaw, nearbyAltNames, longRangePool),
       },
       weekStandout: {
         parseStatus: componentCandidate?.weekStandoutParseStatus || 'absent',


### PR DESCRIPTION
## Summary
Bundle 7: fixes four production bugs found from the April 1 live debug/email run.

- **#79** — AI editorial fallback now adds contextual second sentences (alternative scores, condition quality) instead of returning a bare template restatement
- **#80** — Debug email now cross-checks outdoor comfort source data against the hourly scoring trace and flags any data drift with a visible warning banner
- **#81** — Spur-of-the-moment suggestions are no longer silently dropped when the editorial text fails factual validation; components are recovered from whichever provider returned them via cross-candidate fallback
- **#82** — weekStandout field is now recovered from the secondary provider when the primary provider omits it, using the same cross-candidate fallback mechanism

### Root cause (#81 & #82)
`reusableComponents` was gated on `factualCheck.passed`, so when both providers' editorial text failed factual validation, all structured fields (spur, weekStandout, composition bullets) were thrown away — even though those fields have their own independent validation pipelines. Changed to gate on successful JSON parse instead.

Closes #79, closes #80, closes #81, closes #82

## Test plan
- [ ] All 375 existing tests pass (verified locally)
- [ ] TypeScript compiles with no errors (verified locally)
- [ ] Verify next live debug email shows spur suggestion trace instead of "None" when AI returns one
- [ ] Verify next live debug email shows data-drift warning if outdoor comfort and scoring traces diverge
- [ ] Verify fallback editorial text includes a second sentence in the next template-fallback scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)