### PR TITLE
Chunk 7: Make src/contracts/* the obvious public cross-layer contract surface

### DIFF
--- a/src/adapters/n8n/mappers/to-scored-forecast.ts
+++ b/src/adapters/n8n/mappers/to-scored-forecast.ts
@@ -6,10 +6,14 @@
  * This avoids unsafe casting and makes the adapter boundary explicit.
  */
 
-import type { ScoredForecastContext } from '../../../types/scored-forecast.js';
+import type {
+  ScoredForecastContext,
+  AltLocation,
+  LongRangeCard,
+  DarkSkyAlertCard,
+  SessionRecommendationSummary,
+} from '../../../contracts/index.js';
 import type { RenderableRuntimeContext } from '../contracts/final-runtime-payload.js';
-import type { AltLocation, LongRangeCard, DarkSkyAlertCard } from '../../../types/brief.js';
-import type { SessionRecommendationSummary } from '../../../types/session-score.js';
 import type { AuroraSignal } from '../../../lib/aurora-providers.js';
 
 /**

--- a/src/contracts/brief.ts
+++ b/src/contracts/brief.ts
@@ -1,3 +1,10 @@
+/**
+ * Public contract surface for brief-related types.
+ *
+ * This module exports types shared across app, domain, presenters, and adapters.
+ * Import from here rather than from internal implementation paths.
+ */
+
 export {
   BRIEF_JSON_SCHEMA_VERSION,
 } from '../types/brief.js';
@@ -13,5 +20,6 @@ export type {
   NextDayHour,
   SpurOfTheMomentSuggestion,
   Window,
+  WindowDisplayPlan,
   WindowHour,
 } from '../types/brief.js';

--- a/src/contracts/editorial.ts
+++ b/src/contracts/editorial.ts
@@ -1,3 +1,10 @@
+/**
+ * Public contract surface for editorial resolution types.
+ *
+ * This module exports types shared across app, domain, presenters, and adapters.
+ * Import from here rather than from internal implementation paths.
+ */
+
 export type {
   BriefContext,
   LongRangeSpurCandidate,

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Public contract surface for cross-layer types.
+ *
+ * This module is the single entry point for types shared across app, domain,
+ * presenters, and adapters. Import from here rather than from internal paths.
+ *
+ * @example
+ * ```typescript
+ * import type { BriefJson, ScoredForecastContext, EditorialDecision } from '../contracts/index.js';
+ * ```
+ */
+
+// Brief types (payloads, render inputs, window definitions)
+export {
+  BRIEF_JSON_SCHEMA_VERSION,
+} from './brief.js';
+
+export type {
+  AltLocation,
+  BriefJson,
+  BriefRenderInput,
+  CarWash,
+  DarkSkyAlertCard,
+  DaySummary,
+  LongRangeCard,
+  NextDayHour,
+  SpurOfTheMomentSuggestion,
+  Window,
+  WindowDisplayPlan,
+  WindowHour,
+} from './brief.js';
+
+// Scored forecast context (runtime context for rendering)
+export type { ScoredForecastContext } from './scored-forecast.js';
+
+// Session scoring types
+export type {
+  SessionConfidence,
+  SessionEvaluator,
+  SessionId,
+  SessionRecommendationSummary,
+  SessionScore,
+} from './session-score.js';
+
+// Editorial resolution types
+export type {
+  BriefContext,
+  LongRangeSpurCandidate,
+  ResolveEditorialInput,
+  ResolveEditorialOutput,
+  SpurSuggestion,
+} from './editorial.js';
+
+// Run photo brief use case types
+export type {
+  EditorialDecision,
+} from './run-photo-brief.js';

--- a/src/contracts/run-photo-brief.ts
+++ b/src/contracts/run-photo-brief.ts
@@ -1,1 +1,10 @@
-export * from '../app/run-photo-brief/contracts.js';
+/**
+ * Public contract surface for run-photo-brief use case.
+ *
+ * This module exports the main use case contracts shared across layers.
+ * Import from here rather than from internal implementation paths.
+ */
+
+export type {
+  EditorialDecision,
+} from '../app/run-photo-brief/contracts.js';

--- a/src/contracts/scored-forecast.ts
+++ b/src/contracts/scored-forecast.ts
@@ -1,1 +1,8 @@
+/**
+ * Public contract surface for scored forecast context.
+ *
+ * This module exports the context type shared across app, domain, presenters, and adapters.
+ * Import from here rather than from internal implementation paths.
+ */
+
 export type { ScoredForecastContext } from '../types/scored-forecast.js';

--- a/src/contracts/session-score.ts
+++ b/src/contracts/session-score.ts
@@ -1,0 +1,14 @@
+/**
+ * Public contract surface for session scoring types.
+ *
+ * This module exports types shared across app, domain, presenters, and adapters.
+ * Import from here rather than from internal implementation paths.
+ */
+
+export type {
+  SessionConfidence,
+  SessionEvaluator,
+  SessionId,
+  SessionRecommendationSummary,
+  SessionScore,
+} from '../types/session-score.js';

--- a/src/presenters/brief-json/render-brief-json.ts
+++ b/src/presenters/brief-json/render-brief-json.ts
@@ -1,9 +1,9 @@
-import type { EditorialDecision } from '../../app/run-photo-brief/contracts.js';
-import type { ScoredForecastContext } from '../../types/scored-forecast.js';
 import {
   BRIEF_JSON_SCHEMA_VERSION,
+  type EditorialDecision,
+  type ScoredForecastContext,
   type BriefJson,
-} from '../../types/brief.js';
+} from '../../contracts/index.js';
 
 export function renderBriefAsJson(
   scoredContext: ScoredForecastContext,


### PR DESCRIPTION
## Summary
Makes `src/contracts/*` the obvious public cross-layer contract surface for types shared across app, domain, presenters, and adapters.

## Changes
- **New file**: `src/contracts/index.ts` - Single entry point for all cross-layer contracts
- **New file**: `src/contracts/session-score.ts` - Session scoring types contract
- **Updated**: All contract modules now have JSDoc headers explaining their purpose
- **Updated**: `src/contracts/brief.ts` - Added `WindowDisplayPlan` export
- **Updated**: `src/presenters/brief-json/render-brief-json.ts` - Now imports from contracts
- **Updated**: `src/adapters/n8n/mappers/to-scored-forecast.ts` - Now imports from contracts

## Contract Surface
The following types are now available from `src/contracts/index.ts`:

### Brief Types
- `BriefJson`, `BriefRenderInput`, `AltLocation`, `Window`, `DaySummary`
- `CarWash`, `DarkSkyAlertCard`, `LongRangeCard`
- `SpurOfTheMomentSuggestion`, `WindowDisplayPlan`, `WindowHour`

### Scored Forecast
- `ScoredForecastContext`

### Session Scoring
- `SessionId`, `SessionRecommendationSummary`, `SessionScore`
- `SessionConfidence`, `SessionEvaluator`

### Editorial
- `BriefContext`, `EditorialDecision`, `SpurSuggestion`
- `ResolveEditorialInput`, `ResolveEditorialOutput`

## Backward Compatibility
- Internal paths (`src/types/*`, `src/domain/*`, etc.) continue to work
- No breaking changes to existing code
- Incremental migration path for consumers

## Validation
- [x] `npx vitest run src/adapters/n8n/format-messages.adapter.test.ts` - 62 tests pass
- [x] `npx vitest run src/lib/best-windows.test.ts` - 9 tests pass
- [x] `npx vitest run src/lib/score-alternatives.test.ts` - 20 tests pass
- [x] `npx vitest run src/domain/scoring/score-all-days.test.ts` - 12 tests pass
- [x] `npm run typecheck` - No TypeScript errors

## Constraints Met
- ✅ Shared payloads have one obvious public import surface
- ✅ Cross-layer code can use `src/contracts/*`
- ✅ Internal-only types remain in `src/types/*`
- ✅ No runtime behavior changes
- ✅ Incremental approach - no giant reorganisation

Closes #118
