### PR TITLE
docs: round out architecture and slice primers across the repo (closes #114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,68 @@ This repo owns the application code:
 - email, site, and Telegram rendering
 - n8n workflow source and generated workflow JSON
 
-Branch layout:
+## What This System Does
+
+Aperture fetches weather forecast data from multiple providers (Open-Meteo, OpenWeather, METAR, etc.), scores the conditions for photography quality, generates editorial content via AI providers (Groq, Gemini), and renders the results as email, web page, Telegram message, and machine-readable JSON. The entire pipeline runs on a schedule via n8n, with output published to GitHub Pages and sent via email/Telegram.
+
+## Branch Layout
+
 - `main`: application source
 - `gh-pages`: published static site output for `https://garyneville.github.io/aperture/`
 
-Key paths:
+## Key Paths
+
 - `src/app/run-photo-brief`: orchestration entrypoint
 - `src/domain`: scoring and editorial domain logic
 - `src/presenters`: email, site, Telegram, and brief JSON presenters
 - `src/adapters/n8n`: n8n runtime adapters
+- `src/contracts`: public cross-layer type contracts
 - `workflow/source/skeleton.json`: workflow source
 - `generated/workflow/photography-weather-brief.json`: generated n8n workflow artifact
 
-Common commands:
+## Common Commands
+
 - `npm test`
 - `npm run typecheck`
 - `npm run build`
+
+## Where to Make Changes
+
+| If you want to... | Look in... |
+|-------------------|------------|
+| Change how weather is scored | `src/domain/scoring/` |
+| Change AI prompts or fallbacks | `src/domain/editorial/` |
+| Change email appearance | `src/presenters/email/` |
+| Change site appearance | `src/presenters/site/sections/` |
+| Change Telegram format | `src/presenters/telegram/` |
+| Change the workflow pipeline | `src/app/run-photo-brief/` |
+| Change n8n integration | `src/adapters/n8n/` |
+| Add a new output format | `src/presenters/` (new folder) |
+
+## Documentation
+
+- [`docs/architecture.md`](./docs/architecture.md) — System architecture and data flow
+- [`src/app/README.md`](./src/app/README.md) — App layer orchestration
+- [`src/app/run-photo-brief/README.md`](./src/app/run-photo-brief/README.md) — Main use case
+- [`src/domain/README.md`](./src/domain/README.md) — Domain layer (scoring, editorial)
+- [`src/domain/scoring/README.md`](./src/domain/scoring/README.md) — Scoring details
+- [`src/domain/editorial/README.md`](./src/domain/editorial/README.md) — Editorial details
+- [`src/presenters/README.md`](./src/presenters/README.md) — Presenter layer overview
+- [`src/presenters/email/README.md`](./src/presenters/email/README.md) — Email presenter
+- [`src/presenters/site/README.md`](./src/presenters/site/README.md) — Site presenter
+- [`src/presenters/telegram/README.md`](./src/presenters/telegram/README.md) — Telegram presenter
+- [`src/presenters/brief-json/README.md`](./src/presenters/brief-json/README.md) — JSON output
+- [`src/presenters/shared/README.md`](./src/presenters/shared/README.md) — Shared primitives
+- [`src/contracts/README.md`](./src/contracts/README.md) — Public contracts
+- [`src/adapters/n8n/README.md`](./src/adapters/n8n/README.md) — n8n adapter boundary
+- [`src/lib/README.md`](./src/lib/README.md) — Shared utilities
+- [`workflow/build/README.md`](./workflow/build/README.md) — Workflow generation
+
+## New Contributors / Coding Agents Start Here
+
+1. Read [`docs/architecture.md`](./docs/architecture.md) for the system overview
+2. Read [`src/app/run-photo-brief/README.md`](./src/app/run-photo-brief/README.md) to understand the main workflow
+3. Read the relevant layer primer (`src/domain/`, `src/presenters/`, etc.) for the area you're changing
+4. Check the working rules in each README — they explain what belongs where
 
 The homelab/infrastructure repo is `garyneville/home`. This repo is the source of truth for the photography application itself.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,14 +15,57 @@ The canonical application flow is implemented by [`src/app/run-photo-brief/use-c
 
 That sequence is the main architectural spine for both contributors and generated workflows.
 
+## Data Flow (Plain English)
+
+Here's how data moves through the system:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              DATA FLOW                                       │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+External APIs (weather, air quality, aurora)
+         ↓
+┌─────────────────┐
+│  n8n Adapters   │  ← Normalize external payloads, read config
+│ (src/adapters)  │
+└────────┬────────┘
+         ↓
+┌─────────────────┐
+│  App Layer      │  ← Orchestrate the pipeline
+│ (src/app)       │
+└────────┬────────┘
+         ↓
+┌─────────────────┐
+│  Domain Layer   │  ← Business logic: scoring + editorial
+│ (src/domain)    │
+└────────┬────────┘
+         ↓
+┌─────────────────┐
+│  Presenters     │  ← Format outputs: email, site, Telegram, JSON
+│ (src/presenters)│
+└────────┬────────┘
+         ↓
+   Email, Site, Telegram, JSON
+```
+
+The **App Layer** (`src/app/run-photo-brief/use-case.ts`) coordinates everything but delegates all actual work:
+- It doesn't score weather — it calls `src/domain/scoring/`
+- It doesn't generate editorial — it calls `src/domain/editorial/`
+- It doesn't format output — it calls `src/presenters/`
+
+This makes the pipeline easy to test: each layer can be tested in isolation, and the use case can be tested with injected test doubles.
+
 ## Layers
 
 ### App
 
 - [`src/app/run-photo-brief/use-case.ts`](../src/app/run-photo-brief/use-case.ts)
-  The orchestration entrypoint.
+  The orchestration entrypoint. Sequences the 6-stage pipeline with timing.
 - [`src/app/run-photo-brief/contracts.ts`](../src/app/run-photo-brief/contracts.ts)
   Stable run-level contracts for forecast acquisition, editorial resolution, and rendered outputs.
+
+**Rule:** Code here coordinates between layers. It doesn't implement business logic or formatting.
 
 ### Domain
 
@@ -31,12 +74,14 @@ That sequence is the main architectural spine for both contributors and generate
 - [`src/domain/editorial`](../src/domain/editorial)
   Prompt construction plus AI response parsing, validation, fallback selection, and composition filtering.
 
+**Rule:** Code here is pure business logic. No knowledge of n8n, email formatting, or HTTP clients.
+
 ### Presenters
 
 - [`src/presenters/email`](../src/presenters/email)
   Email rendering and debug email output.
 - [`src/presenters/site`](../src/presenters/site)
-  Static-site renderer.
+  Static-site renderer with modular sections.
 - [`src/presenters/telegram`](../src/presenters/telegram)
   Telegram formatting.
 - [`src/presenters/brief-json`](../src/presenters/brief-json)
@@ -44,15 +89,26 @@ That sequence is the main architectural spine for both contributors and generate
 - [`src/presenters/shared`](../src/presenters/shared)
   Cross-presenter render primitives (icons, colours, stat helpers).
 
+**Rule:** Code here transforms data into presentation formats. No business logic, no API calls.
+
 ### Library
 
 - [`src/lib`](../src/lib)
   Shared infrastructure: astronomy helpers, scoring utilities, location data, debug context, icon assets, and other cross-cutting modules used by domain and presenter layers.
 
+**Rule:** Modules here must not import from `src/domain`, `src/presenters`, or `src/app`. They may import from each other and from `src/types`.
+
 ### Adapters
 
 - [`src/adapters/n8n`](../src/adapters/n8n)
   n8n runtime boundary: input normalization, config lookup, workflow-node shaping, and app/domain invocation.
+
+**Rule:** Keep adapters thin. If business logic starts to dominate, extract it into `src/app`, `src/domain`, or `src/presenters`.
+
+### Contracts
+
+- [`src/contracts`](../src/contracts)
+  Public cross-layer type contracts. Import from here rather than from internal implementation paths.
 
 ### Workflow Build
 
@@ -65,7 +121,52 @@ That sequence is the main architectural spine for both contributors and generate
 - [`generated/workflow/photography-weather-brief.json`](../generated/workflow/photography-weather-brief.json)
   Generated n8n workflow output.
 
-## Public entrypoints
+**Rule:** Build-time code only. No runtime dependencies.
+
+## Runtime vs Build-Time
+
+**Runtime:** Everything in `src/` runs when the brief is generated:
+- Adapters receive n8n input
+- App orchestrates the pipeline
+- Domain scores and generates editorial
+- Presenters format outputs
+- Adapters deliver results
+
+**Build-Time:** Code in `workflow/build/` runs during development to generate the n8n workflow:
+- `compile-email.ts` — Compiles MJML to TypeScript
+- `assemble.ts` — Bundles adapters and generates workflow JSON
+
+This separation means:
+- The application logic is independent of n8n
+- The workflow artifact is generated, not hand-edited
+- The system can run without n8n (see below)
+
+## n8n Integration
+
+Currently, n8n is the runtime host:
+
+1. **n8n trigger** (schedule or webhook) starts the workflow
+2. **n8n HTTP nodes** fetch forecast data from providers
+3. **n8n code nodes** call adapter functions in `src/adapters/n8n/`
+4. **Adapters** normalize input and call the app layer
+5. **App layer** orchestrates domain and presenters
+6. **Adapters** shape outputs for downstream n8n nodes
+7. **n8n nodes** send email, Telegram, and commit to gh-pages
+
+**Key point:** n8n surrounds the application but is not part of it. The app code in `src/` has no n8n imports. Adapters provide the bridge.
+
+### Running Without n8n
+
+The architecture supports running without n8n:
+
+1. Replace the adapter layer with HTTP handlers (Express, Fastify, etc.)
+2. Implement `acquireForecastBundle()` to call weather APIs directly
+3. Call `runPhotoBrief()` from your route handler
+4. Implement `deliverOutputs()` to send via your preferred channels
+
+The domain and presenter layers are completely independent of n8n. Only the adapter layer changes.
+
+## Public Entrypoints
 
 These are the stable seams that external callers and generated workflows should depend on:
 
@@ -78,6 +179,25 @@ These are the stable seams that external callers and generated workflows should 
 
 Everything else is internal and free to evolve without a migration period.
 
+## Contracts vs Types
+
+**Contracts (`src/contracts/`)** are for cross-layer sharing:
+- Stable public API
+- Versioned when breaking changes occur
+- Import from `../contracts/` in layer code
+- Re-exported from `src/contracts/index.ts`
+
+**Types (`src/types/`)** are for internal use:
+- Implementation details
+- May change without notice
+- Don't import across layer boundaries
+- Import only within the same layer
+
+When adding a new shared type:
+1. Start in the layer that owns it (e.g., `src/domain/scoring/`)
+2. If other layers need it, re-export from `src/contracts/`
+3. Import from contracts in consuming layers
+
 ## Guardrails
 
 Refactors should keep these green at every step:
@@ -86,3 +206,21 @@ Refactors should keep these green at every step:
 - `npm test`
 - `npm run build`
 - `npm run verify:generated`
+
+## Documentation Index
+
+- [`src/app/README.md`](../src/app/README.md) — App layer orchestration
+- [`src/app/run-photo-brief/README.md`](../src/app/run-photo-brief/README.md) — Main use case
+- [`src/domain/README.md`](../src/domain/README.md) — Domain layer overview
+- [`src/domain/scoring/README.md`](../src/domain/scoring/README.md) — Scoring details
+- [`src/domain/editorial/README.md`](../src/domain/editorial/README.md) — Editorial details
+- [`src/presenters/README.md`](../src/presenters/README.md) — Presenter layer overview
+- [`src/presenters/email/README.md`](../src/presenters/email/README.md) — Email presenter
+- [`src/presenters/site/README.md`](../src/presenters/site/README.md) — Site presenter
+- [`src/presenters/telegram/README.md`](../src/presenters/telegram/README.md) — Telegram presenter
+- [`src/presenters/brief-json/README.md`](../src/presenters/brief-json/README.md) — JSON output
+- [`src/presenters/shared/README.md`](../src/presenters/shared/README.md) — Shared primitives
+- [`src/contracts/README.md`](../src/contracts/README.md) — Public contracts
+- [`src/adapters/n8n/README.md`](../src/adapters/n8n/README.md) — n8n adapter boundary
+- [`src/lib/README.md`](../src/lib/README.md) — Shared utilities
+- [`workflow/build/README.md`](../workflow/build/README.md) — Workflow generation

--- a/src/app/README.md
+++ b/src/app/README.md
@@ -1,0 +1,67 @@
+# App Layer Primer
+
+This folder contains the application orchestration layer. Code here wires together domain logic, presenters, and adapters to form complete use cases.
+
+## Purpose
+
+- orchestrate the main application workflows
+- coordinate between domain logic, presenters, and external adapters
+- manage the sequencing of operations (acquire → score → editorial → render → deliver)
+- provide stable entrypoints for external callers and generated workflows
+
+## Public Entry Points
+
+- [`run-photo-brief/use-case.ts`](./run-photo-brief/use-case.ts)
+  The canonical orchestration spine. Implements the complete photo brief pipeline from forecast acquisition through delivery.
+
+- [`run-photo-brief/contracts.ts`](./run-photo-brief/contracts.ts)
+  Stable run-level contracts for forecast acquisition, editorial resolution, and rendered outputs.
+
+## Main Files / Module Map
+
+- `run-photo-brief/`
+  - `use-case.ts` — Main orchestration use case with stage timing
+  - `contracts.ts` — Type contracts for the use case inputs/outputs
+  - `deliver-site.ts` — Site delivery helper
+  - `use-case.test.ts` — Unit tests for the orchestration logic
+
+## Data In / Data Out
+
+**Input:**
+- Forecast bundle from weather providers (via adapter)
+- Runtime configuration
+- Scoring and editorial dependencies (injected for testability)
+
+**Output:**
+- `StandaloneBriefRun` containing all intermediate and final artifacts
+- Rendered outputs (email HTML, site HTML, Telegram message, brief JSON)
+- Optional persistence and delivery side effects
+
+## What Belongs Here
+
+- Use case orchestration that coordinates multiple layers
+- Sequencing logic for multi-stage operations
+- Integration between domain logic and external concerns
+- Code that would live in a "service" or "application service" layer in other architectures
+
+## What Does Not Belong Here
+
+- **Business logic** should live in `src/domain` (scoring rules, editorial decisions)
+- **Presentation formatting** should live in `src/presenters` (HTML generation, message formatting)
+- **External adapter concerns** should live in `src/adapters` (n8n normalization, HTTP clients)
+- **Pure utilities** should live in `src/lib`
+
+## Tests
+
+- [`run-photo-brief/use-case.test.ts`](./run-photo-brief/use-case.test.ts)
+
+## Working Rule
+
+If code is coordinating between multiple layers or managing the sequence of a workflow, it belongs in `app`. If code is implementing business rules or calculations, it belongs in `domain`. Keep app layer thin—most complexity should push down to domain or across to presenters.
+
+## Related Docs
+
+- [`../domain/scoring/README.md`](../domain/scoring/README.md) — Scoring domain logic
+- [`../domain/editorial/README.md`](../domain/editorial/README.md) — Editorial domain logic
+- [`../presenters/README.md`](../presenters/README.md) — Presenter layer overview
+- [`../adapters/n8n/README.md`](../adapters/n8n/README.md) — n8n adapter boundary

--- a/src/app/run-photo-brief/README.md
+++ b/src/app/run-photo-brief/README.md
@@ -1,0 +1,103 @@
+# Run Photo Brief Use Case
+
+This folder contains the canonical orchestration spine for the photo brief application. It implements the end-to-end pipeline from forecast acquisition through rendered output delivery.
+
+## Purpose
+
+- run the complete photo brief workflow in sequence
+- time each stage for performance monitoring
+- assemble the final `StandaloneBriefRun` artifact with all intermediate results
+- support dependency injection for testing and alternative implementations
+
+## Public Entry Points
+
+- [`use-case.ts`](./use-case.ts)
+  `runPhotoBrief(deps)` — Main entry point. Accepts injected dependencies for all stages, times execution, and returns the complete run artifact.
+
+- [`contracts.ts`](./contracts.ts)
+  Type definitions for the use case: `StandaloneRunnerDependencies`, `StandaloneBriefRun`, `ForecastBundle`, `EditorialRequest`, `EditorialDecision`, `RenderedOutputs`, and stage types.
+
+## Main Files / Module Map
+
+- `use-case.ts`
+  The orchestration logic. Implements a 6-stage pipeline:
+  1. **acquire** — Fetch forecast payloads from providers
+  2. **score** — Score hourly and daily conditions
+  3. **buildEditorialRequest** — Build the editorial prompt
+  4. **resolveEditorial** — Resolve editorial output with fallbacks
+  5. **render** — Render all presentation outputs
+  6. **persist/deliver** — Optional persistence and delivery
+
+- `contracts.ts`
+  Stable contracts for the use case. These are the types that external callers should depend on.
+
+- `deliver-site.ts`
+  Helper for site output delivery.
+
+- `use-case.test.ts`
+  Unit tests demonstrating how to inject test doubles for each stage.
+
+## Data In / Data Out
+
+**Input (via `StandaloneRunnerDependencies`):**
+```typescript
+{
+  acquireForecastBundle(): Promise<ForecastBundle>
+  scoreForecast(bundle): Promise<ScoredForecastContext>
+  buildEditorialRequest(context): Promise<EditorialRequest>
+  resolveEditorial(request): Promise<EditorialDecision>
+  renderBrief(context, editorial): Promise<RenderedOutputs>
+  persistRun?(run): Promise<void>      // optional
+  deliverOutputs?(run): Promise<void>  // optional
+  now?(): Date                         // optional, for testability
+}
+```
+
+**Output (`StandaloneBriefRun`):**
+```typescript
+{
+  generatedAt: string
+  forecast: ForecastBundle
+  scoredContext: ScoredForecastContext
+  editorialRequest: EditorialRequest
+  editorial: EditorialDecision
+  outputs: RenderedOutputs      // { briefJson, telegramMsg, emailHtml, siteHtml?, ... }
+  stageTimingsMs: Record<stage, number>
+}
+```
+
+## What Belongs Here
+
+- orchestration logic that sequences domain operations
+- stage timing and performance tracking
+- assembly of the final run artifact
+- dependency injection interfaces for testability
+
+## What Does Not Belong Here
+
+- **Forecast acquisition logic** — belongs in adapters
+- **Scoring algorithms** — belongs in `src/domain/scoring`
+- **Editorial resolution** — belongs in `src/domain/editorial`
+- **Rendering/formatting** — belongs in `src/presenters`
+- **Persistence/delivery details** — belongs in adapters or infrastructure
+
+## Tests
+
+- [`use-case.test.ts`](./use-case.test.ts)
+  Demonstrates injecting test doubles for each dependency. Tests verify:
+  - All stages are called in order
+  - Stage timings are recorded
+  - The complete run artifact is assembled correctly
+  - Optional persist/deliver hooks are invoked when provided
+
+## Working Rule
+
+The use case file should remain thin. Each stage delegates to domain or adapter layers. The use case owns the sequencing and timing, not the business logic. When adding new stages, extend `StandaloneRunnerDependencies` and add the stage to the `RunnerStage` union type.
+
+## Related Docs
+
+- [`../../domain/scoring/README.md`](../../domain/scoring/README.md) — Scoring logic delegated in stage 2
+- [`../../domain/editorial/README.md`](../../domain/editorial/README.md) — Editorial logic delegated in stages 3-4
+- [`../../presenters/README.md`](../../presenters/README.md) — Rendering logic delegated in stage 5
+- [`../../adapters/n8n/README.md`](../../adapters/n8n/README.md) — How n8n calls this use case
+- [`../../docs/architecture.md`](../../docs/architecture.md) — Overall architecture and pipeline

--- a/src/domain/README.md
+++ b/src/domain/README.md
@@ -1,0 +1,118 @@
+# Domain Layer Primer
+
+This folder contains the business logic for weather scoring and editorial generation. This is where weather data becomes photography recommendations.
+
+## Purpose
+
+- implement weather/photography decision logic independent of presentation
+- score forecast conditions for photography quality
+- generate editorial content from scored forecasts
+- provide pure functions that transform data without side effects
+
+## Public Entry Points
+
+- [`scoring/`](./scoring/)
+  - `score-all-days.ts` — Main scoring orchestrator
+  - `features/derive-hour-features.ts` — Feature engineering for hour scoring
+  - `sessions/index.ts` — Session recommendations and ranking
+
+- [`editorial/`](./editorial/)
+  - `prompt/build-prompt.ts` — Editorial prompt construction
+  - `resolution/resolve-editorial.ts` — Editorial resolution with fallbacks
+
+- [`../contracts/`](../contracts/)
+  Re-export surface for stable domain types:
+  - `scored-forecast.ts` — `ScoredForecastContext`
+  - `editorial.ts` — `EditorialDecision`, `BriefContext`
+  - `session-score.ts` — `SessionScore`, `SessionRecommendationSummary`
+
+## Main Files / Module Map
+
+### Scoring (`scoring/`)
+
+- `score-all-days.ts`
+  Orchestrates hourly scoring, day summaries, and session recommendation attachment.
+
+- `features/`
+  Hour-level feature engineering and weather metric derivation.
+
+- `sessions/`
+  Built-in session evaluators (golden hour, blue hour, astro, etc.), cross-hour selection logic, and recommendation summary generation.
+
+### Editorial (`editorial/`)
+
+- `prompt/build-prompt.ts`
+  Builds the AI provider prompt from scored forecast context.
+
+- `resolution/resolve-editorial.ts`
+  Orchestrates provider choice, response validation, fallback selection, and debug trace output.
+
+- `resolution/parse.ts`
+  Provider response parsing (JSON/text extraction).
+
+- `resolution/validation.ts`
+  Factual and stylistic quality checks on provider output.
+
+- `resolution/composition.ts`
+  Composition bullet filtering and normalization.
+
+- `resolution/week-standout.ts`
+  Week standout text generation.
+
+- `resolution/spur-suggestion.ts`
+  Spur-of-the-moment suggestion logic.
+
+## Data Flow
+
+```
+Raw Forecast Data
+       ↓
+[features/derive-hour-features] → Hour-level features
+       ↓
+[scoring/score-all-days] → ScoredForecastContext (windows, daily summaries, sessions)
+       ↓
+[editorial/prompt/build-prompt] → EditorialRequest (prompt + context)
+       ↓
+[editorial/resolution/resolve-editorial] → EditorialDecision (AI text, bullets, week insight)
+```
+
+## What Belongs Here
+
+- Weather scoring algorithms and heuristics
+- Session recommendation logic (ranking, timing, quality thresholds)
+- Editorial prompt construction and AI response handling
+- Validation and fallback logic for editorial content
+- Pure business logic with no knowledge of n8n, email formatting, or HTTP clients
+
+## What Does Not Belong Here
+
+- **HTTP/API calls** — belongs in adapters
+- **Email/HTML formatting** — belongs in presenters
+- **n8n-specific code** — belongs in `src/adapters/n8n`
+- **Orchestration/sequencing** — belongs in `src/app`
+- **Shared utilities** — belongs in `src/lib`
+
+## Tests
+
+Each submodule has co-located tests:
+
+- `scoring/`
+  - `score-all-days.test.ts`
+  - `features/derive-hour-features.test.ts`
+  - `sessions/index.test.ts`
+
+- `editorial/`
+  - `prompt/build-prompt.test.ts`
+  - (Additional coverage via `../../adapters/n8n/format-messages.adapter.test.ts`)
+
+## Working Rule
+
+Domain code should be pure and testable in isolation. It receives data, transforms it, and returns new data. No side effects, no direct I/O, no knowledge of how the results will be presented. If you need to add a new scoring rule or editorial fallback, it belongs here.
+
+## Related Docs
+
+- [`./scoring/README.md`](./scoring/README.md) — Detailed scoring documentation
+- [`./editorial/README.md`](./editorial/README.md) — Detailed editorial documentation
+- [`../app/run-photo-brief/README.md`](../app/run-photo-brief/README.md) — How the app layer orchestrates domain logic
+- [`../contracts/README.md`](../contracts/README.md) — Public contract surface for domain types
+- [`../lib/README.md`](../lib/README.md) — Shared utilities used by domain code

--- a/src/presenters/README.md
+++ b/src/presenters/README.md
@@ -1,0 +1,127 @@
+# Presenter Layer Primer
+
+This folder contains all output formatting logic. Presenters transform structured brief data into presentation formats: email HTML, site HTML, Telegram messages, and machine-readable JSON.
+
+## Purpose
+
+- turn structured brief data into presentation-ready output
+- isolate formatting concerns from business logic
+- support multiple output formats from the same underlying data
+- provide consistent styling and layout across channels
+
+## Public Entry Points
+
+- [`email/index.ts`](./email/index.ts)
+  Email HTML rendering and debug email output.
+
+- [`site/format-site.ts`](./site/format-site.ts)
+  Static site HTML rendering.
+
+- [`telegram/format-telegram.ts`](./telegram/format-telegram.ts)
+  Telegram message formatting.
+
+- [`brief-json/render-brief-json.ts`](./brief-json/render-brief-json.ts)
+  Canonical machine-readable brief output.
+
+- [`shared/brief-primitives.ts`](./shared/brief-primitives.ts)
+  Cross-presenter render primitives (colors, icons, stat helpers).
+
+## Main Files / Module Map
+
+### Email (`email/`)
+
+- `index.ts` — Public entry point for email rendering
+- `shared.ts` — Cross-cutting render helpers
+- `time-aware.ts` — Rerun-aware window display logic
+- `kit-advisory.ts` — Rule-based kit recommendation logic
+- `next-day.ts` — Outdoor comfort scoring and forecast tables
+- `debug-email.ts` — Internal debug email rendering
+- `format-email.test.ts`, `debug-email.test.ts`, etc. — Tests
+
+### Site (`site/`)
+
+- `format-site.ts` — Main site formatter, assembles sections into complete page
+- `site-layout.ts` — HTML document wrapper and layout
+- `sections/` — Modular section components:
+  - `hero.ts` — Hero score card
+  - `signals.ts` — Signal indicator cards (aurora, moon, etc.)
+  - `window.ts` — Shooting window display
+  - `daylight-utility.ts` — Daylight utility bar
+  - `session-rec.ts` — Session recommendation card
+  - `creative-spark.ts` — Creative spark/AI text section
+  - `kit-advisory.ts` — Kit advisory card
+  - `alternatives.ts` — Alternative locations section
+  - `long-range.ts` — Long-range destination section
+  - `hourly-outlook.ts` — Hour-by-hour outlook
+  - `forecast.ts` — Photo forecast and car wash cards
+  - `spur-of-moment.ts` — Spur-of-the-moment suggestion
+  - `footer.ts` — Footer key/legend
+  - `shared.ts` — Shared section utilities
+
+### Telegram (`telegram/`)
+
+- `format-telegram.ts` — Telegram message formatter with HTML tags
+
+### Brief JSON (`brief-json/`)
+
+- `render-brief-json.ts` — Machine-readable JSON output renderer
+- `render-brief-json.test.ts` — Tests
+
+### Shared (`shared/`)
+
+- `brief-primitives.ts` — Cross-presenter primitives: colors, typography, icons, stat grids, weather/moon icons
+
+## Data In / Data Out
+
+**Input:**
+All presenters receive `BriefRenderInput` (from [`../types/brief.ts`](../types/brief.ts)), which includes:
+- Scored windows and daily summaries
+- AI-generated editorial content
+- Session recommendations
+- Alternative locations and long-range destinations
+- Debug context for optional debug output
+
+**Output:**
+- **Email:** HTML string (email-compatible markup)
+- **Site:** Complete HTML document string
+- **Telegram:** HTML-formatted message string (Telegram HTML subset)
+- **Brief JSON:** Structured JSON object matching `BriefJson` contract
+
+## What Belongs Here
+
+- Formatting and layout logic
+- HTML/markup generation
+- Presentation-specific styling decisions
+- Channel-specific output constraints (email client limits, Telegram HTML tags)
+- Icon rendering and color schemes
+
+## What Does Not Belong Here
+
+- **Business logic** — belongs in `src/domain` (scoring rules, editorial decisions)
+- **Weather calculations** — belongs in `src/domain/scoring` or `src/lib`
+- **Orchestration** — belongs in `src/app`
+- **HTTP/API calls** — belongs in adapters
+- **External configuration** — belongs in adapters or config
+
+## Tests
+
+- `email/format-email.test.ts`
+- `email/debug-email.test.ts`
+- `email/kit-advisory.test.ts`
+- `email/next-day.test.ts`
+- `site/format-site.test.ts`
+- `brief-json/render-brief-json.test.ts`
+
+## Working Rule
+
+Presenters should be pure functions from data to formatted output. They should not fetch data or make decisions about what data to include—that's the domain layer's job. If the same logic is needed across multiple presenters (e.g., color constants, icon rendering), extract it to `shared/`. If formatting logic becomes complex enough to have its own internal modules (like site sections), organize it into subdirectories.
+
+## Related Docs
+
+- [`./email/README.md`](./email/README.md) — Email presenter details
+- [`./site/README.md`](./site/README.md) — Site presenter details
+- [`./telegram/README.md`](./telegram/README.md) — Telegram presenter details
+- [`./brief-json/README.md`](./brief-json/README.md) — Brief JSON details
+- [`./shared/README.md`](./shared/README.md) — Shared primitives details
+- [`../domain/README.md`](../domain/README.md) — Domain layer that feeds presenters
+- [`../types/brief.ts`](../types/brief.ts) — Input type for all presenters

--- a/src/presenters/brief-json/README.md
+++ b/src/presenters/brief-json/README.md
@@ -1,0 +1,139 @@
+# Brief JSON Presenter Primer
+
+This folder contains the machine-readable JSON output renderer. It produces the canonical structured brief representation used for downstream consumption, storage, and API responses.
+
+## Purpose
+
+- render the photo brief as structured JSON matching the `BriefJson` contract
+- provide a stable, versioned schema for machine consumption
+- enable downstream services to parse brief data without HTML scraping
+- support persistence, analytics, and alternative presentation pipelines
+
+## Public Entry Points
+
+- [`render-brief-json.ts`](./render-brief-json.ts)
+  `renderBriefAsJson(scoredContext, editorial)` — Main entry point. Returns a `BriefJson` object conforming to the schema.
+
+## Main Files / Module Map
+
+- `render-brief-json.ts`
+  Single-file presenter that maps `ScoredForecastContext` and `EditorialDecision` to the `BriefJson` schema.
+
+- `render-brief-json.test.ts`
+  Unit tests verifying correct mapping of all fields and schema compliance.
+
+## Data In / Data Out
+
+**Input:**
+```typescript
+// From domain scoring
+scoredContext: ScoredForecastContext
+
+// From domain editorial
+editorial: EditorialDecision
+```
+
+**Output (`BriefJson`):**
+```typescript
+{
+  schemaVersion: string        // "1.0" (from contracts)
+  generatedAt: string | null
+  location: {
+    name: string | null
+    timezone: string | null
+    latitude: number | null
+    longitude: number | null
+  }
+  dontBother: boolean
+  windows: Window[]
+  todayCarWash: CarWash
+  dailySummary: DaySummary[]
+  altLocations: AltLocation[]
+  closeContenders: AltLocation[]
+  noAltsMsg: string | undefined
+  // ... (see ../../contracts/brief.ts for complete type)
+  aiText: string
+  compositionBullets: string[]
+  weekInsight: string
+  spurOfTheMoment: SpurSuggestion | undefined
+  geminiInspire: string | undefined
+  debugContext: DebugContext | undefined
+}
+```
+
+## Schema Versioning
+
+The `BriefJson` contract includes a `schemaVersion` field (currently `"1.0"`). When making breaking changes:
+
+1. Update `BRIEF_JSON_SCHEMA_VERSION` in [`../../contracts/brief.ts`](../../contracts/brief.ts)
+2. Update this renderer to handle both old and new data if needed
+3. Update downstream consumers
+4. Document the change in the contracts file
+
+## What Belongs Here
+
+- Mapping domain types to the JSON schema
+- Field selection and ordering for the output
+- Null/default handling for optional fields
+- Schema version handling
+
+## What Does Not Belong Here
+
+- **Business logic** — belongs in `src/domain`
+- **Formatting/presentation** — belongs in sibling presenters (email, site, Telegram)
+- **Schema definition** — belongs in `src/contracts/brief.ts`
+- **Persistence logic** — belongs in adapters or infrastructure
+
+## Tests
+
+- [`render-brief-json.test.ts`](./render-brief-json.test.ts)
+  Tests verify:
+  - All required fields are present
+  - Scored context maps correctly to output fields
+  - Editorial content is included
+  - Schema version is set
+  - Null/undefined handling works correctly
+
+## Working Rule
+
+The Brief JSON presenter is a simple mapper. It should not transform data beyond what's necessary for JSON serialization (e.g., date formatting). Business logic decisions (what to include, how to calculate scores) happen upstream in the domain layer. This layer just packages the results.
+
+## Usage Example
+
+```typescript
+import { renderBriefAsJson } from './render-brief-json.js';
+
+const briefJson = renderBriefAsJson(scoredContext, editorial);
+
+// Use for API response
+response.json(briefJson);
+
+// Use for persistence
+await db.briefs.insert(briefJson);
+
+// Use for downstream processing
+queue.send('brief-generated', briefJson);
+```
+
+## Relationship to Other Presenters
+
+All presenters start from the same domain data:
+
+```
+ScoredForecastContext + EditorialDecision
+         ↓
+    ┌────┴────┬──────────┬──────────┐
+    ↓         ↓          ↓          ↓
+ BriefJson  EmailHTML  SiteHTML  TelegramMsg
+```
+
+- **Brief JSON:** Machine-readable, structured, versioned
+- **Email HTML:** Human-readable, rich formatting, email-compatible
+- **Site HTML:** Human-readable, web-optimized, styled
+- **Telegram:** Human-readable, concise, mobile-optimized
+
+## Related Docs
+
+- [`../../contracts/brief.ts`](../../contracts/brief.ts) — Schema definition
+- [`../../contracts/README.md`](../../contracts/README.md) — Contracts overview
+- [`../README.md`](../README.md) — Presenter layer overview

--- a/src/presenters/shared/README.md
+++ b/src/presenters/shared/README.md
@@ -1,0 +1,115 @@
+# Shared Presenter Primitives Primer
+
+This folder contains cross-cutting render primitives used by multiple presenters. These are presentation utilities that don't belong to any single output channel.
+
+## Purpose
+
+- share common formatting utilities across email, site, and other presenters
+- provide consistent colors, icons, and styling primitives
+- avoid duplication of presentation constants
+- keep individual presenters focused on layout, not utility functions
+
+## Public Entry Points
+
+- [`brief-primitives.ts`](./brief-primitives.ts)
+  Main export file containing colors, fonts, icons, score helpers, and formatting utilities.
+
+## Main Files / Module Map
+
+- `brief-primitives.ts`
+  Single-file module exporting:
+  - **Colors (`C`)** — Centralized color palette from design tokens
+  - **Typography** — Font family constants
+  - **Icons** — Brand logo SVG, utility glyphs
+  - **Score Helpers** — Score thresholds, score state calculation, confidence detail
+  - **Stat Helpers** — Summary stat formatting, confidence formatting
+  - **Car Wash Helpers** — Car wash rating calculation
+
+## Exported Primitives
+
+### Colors (`C` object)
+
+```typescript
+C.page, C.surface, C.surfaceVariant  // Backgrounds
+C.ink, C.muted, C.subtle             // Text
+C.primary, C.secondary, C.tertiary   // Accents
+C.success, C.warning, C.error        // States
+C.accent, C.brand                    // Brand colors
+// ... (see file for complete set)
+```
+
+All colors come from [`../../tokens/tokens.ts`](../../tokens/tokens.ts) and are kept in sync with the design system.
+
+### Score Helpers
+
+```typescript
+SCORE_THRESHOLDS = { excellent: 75, good: 58, marginal: 42 }
+
+scoreState(score): { label, fg, bg, border }
+// Returns 'Excellent', 'Good', 'Marginal', or 'Poor' with appropriate colors
+
+confidenceDetail(confidence): { label, fg, bg, border } | null
+// Returns styling for 'high', 'medium', 'low', or 'unknown' confidence
+```
+
+### Icons
+
+```typescript
+BRAND_LOGO  // SVG string for the aperture logo
+UTILITY_GLYPHS  // Emoji indicators (🚗 / 🚶)
+// Weather and moon icons are in ../../lib/weather-icons.ts and moon-icons.ts
+```
+
+### Typography
+
+```typescript
+FONT  // Base font family
+MONO  // Monospace font family
+```
+
+## What Belongs Here
+
+- Color constants and palettes
+- Score/confidence formatting helpers
+- Icon SVGs and glyphs
+- Typography constants
+- Shared CSS-in-JS patterns
+- General formatting utilities that multiple presenters need
+
+## What Does Not Belong Here
+
+- **Business logic** — belongs in `src/domain`
+- **Presenter-specific layout** — belongs in the individual presenter folders
+- **HTML document structure** — belongs in `../site/site-layout.ts`
+- **Email-specific markup** — belongs in `../email/`
+- **Complex formatting** — if it's specific to one section or output, keep it there
+
+## Working Rule
+
+Keep this layer thin. Only extract to `shared/` when:
+1. At least two presenters need the same utility
+2. It's a genuine presentation concern (color, icon, formatting)
+3. It's not business logic in disguise
+
+When in doubt, start in the specific presenter and extract later. Business logic should not accumulate here—if you find yourself adding scoring rules or editorial decisions, move that code to `src/domain`.
+
+## Relationship to Design Tokens
+
+This module re-exports from the design tokens system:
+
+```
+../../tokens/tokens.ts  (source of truth)
+         ↓
+   brief-primitives.ts  (presenter-friendly exports)
+         ↓
+   ../email/, ../site/  (consuming presenters)
+```
+
+When design tokens change, this module provides a compatibility layer for presenters.
+
+## Related Docs
+
+- [`../email/README.md`](../email/README.md) — Email presenter (major consumer)
+- [`../site/README.md`](../site/README.md) — Site presenter (major consumer)
+- [`../../tokens/tokens.ts`](../../tokens/tokens.ts) — Design token source
+- [`../../lib/README.md`](../../lib/README.md) — Shared library utilities (not presenter-specific)

--- a/src/presenters/site/README.md
+++ b/src/presenters/site/README.md
@@ -1,0 +1,111 @@
+# Site Presenter Primer
+
+This folder contains the static site HTML renderer. It transforms brief data into a complete, styled HTML document suitable for web deployment.
+
+## Purpose
+
+- render the photo brief as a complete HTML web page
+- organize content into modular sections for maintainability
+- share visual styling with email output via shared primitives
+- support both the primary site output and gh-pages deployment
+
+## Public Entry Points
+
+- [`format-site.ts`](./format-site.ts)
+  `formatSite(input)` — Main entry point. Accepts `BriefRenderInput` and returns a complete HTML document string.
+
+- [`site-layout.ts`](./site-layout.ts)
+  `renderSiteDocument(content, options)` — HTML document wrapper with head, styles, and body structure.
+
+## Main Files / Module Map
+
+### Core Formatters
+
+- `format-site.ts`
+  Orchestrates section assembly. Imports all section modules and composes them into the final page content, then passes to `site-layout.ts` for document wrapping.
+
+- `site-layout.ts`
+  HTML document template with CSS variables, responsive styles, and script includes. Wraps the section content in a complete `<!DOCTYPE html>` document.
+
+### Sections (`sections/`)
+
+Each section is a self-contained module that renders one visual area of the page:
+
+| Section | File | Purpose |
+|---------|------|---------|
+| Hero Card | `hero.ts` | Main score display, location, date, primary window highlight |
+| Signal Cards | `signals.ts` | Aurora, moon, sunset hue signal indicators |
+| Window | `window.ts` | Detailed shooting window display with hourly breakdown |
+| Daylight Utility | `daylight-utility.ts` | Sunrise/sunset timeline bar |
+| Session Recommendation | `session-rec.ts` | Recommended photography session card |
+| Creative Spark | `creative-spark.ts` | AI-generated creative text section |
+| Kit Advisory | `kit-advisory.ts` | Photography equipment recommendations |
+| Alternatives | `alternatives.ts` | Nearby alternative locations comparison |
+| Long Range | `long-range.ts` | Long-range destination recommendations |
+| Hourly Outlook | `hourly-outlook.ts` | Hour-by-hour conditions table |
+| Photo Forecast | `forecast.ts` | Multi-day forecast cards |
+| Spur of Moment | `spur-of-moment.ts` | Spur-of-the-moment suggestion card |
+| Footer | `footer.ts` | Legend, key, and footer content |
+| Shared | `shared.ts` | Section utilities and common patterns |
+
+## Data In / Data Out
+
+**Input (`BriefRenderInput`):**
+```typescript
+{
+  dontBother: boolean
+  windows: Window[]
+  dailySummary: DaySummary[]
+  altLocations: AltLocation[]
+  closeContenders: AltLocation[]
+  aiText: string
+  compositionBullets: string[]
+  weekInsight: string
+  sessionRecommendation: SessionRecommendationSummary
+  // ... (see ../../types/brief.ts for complete type)
+}
+```
+
+**Output:**
+Complete HTML document string ready for:
+- Saving to `generated/site/` for the gh-pages branch
+- Direct browser viewing
+- Integration with the n8n workflow delivery step
+
+## What Belongs Here
+
+- HTML markup generation for the site output
+- Section-specific layout and styling
+- Section module organization (one concern per file)
+- Responsive CSS considerations
+- Page-level structure decisions
+
+## What Does Not Belong Here
+
+- **Business logic** — belongs in `src/domain`
+- **Shared icons/colors** — belongs in `../shared/brief-primitives.ts`
+- **Email-specific formatting** — belongs in `../email/`
+- **Telegram formatting** — belongs in `../telegram/`
+
+## Tests
+
+- [`format-site.test.ts`](./format-site.test.ts)
+  Tests for complete page rendering and section inclusion.
+
+## Working Rule
+
+Prefer editing section modules over modifying `format-site.ts` directly. Each section should be self-contained and testable in isolation. When adding a new section:
+
+1. Create a new file in `sections/`
+2. Export a function that takes the input data and returns an HTML string
+3. Import and call it from `format-site.ts`
+4. Add tests for the new section
+
+Keep `format-site.ts` focused on orchestration: gathering data, calling sections in order, and passing the assembled content to `site-layout.ts`.
+
+## Related Docs
+
+- [`../email/README.md`](../email/README.md) — Email presenter (shares content structure)
+- [`../shared/README.md`](../shared/README.md) — Shared primitives (colors, icons)
+- [`../../types/brief.ts`](../../types/brief.ts) — Input type definition
+- [`../../app/run-photo-brief/README.md`](../../app/run-photo-brief/README.md) — How site rendering fits into the pipeline

--- a/src/presenters/telegram/README.md
+++ b/src/presenters/telegram/README.md
@@ -1,0 +1,133 @@
+# Telegram Presenter Primer
+
+This folder contains the Telegram message formatter. It transforms brief data into HTML-formatted messages suitable for Telegram's Bot API.
+
+## Purpose
+
+- render the photo brief as a Telegram HTML message
+- work within Telegram's HTML subset constraints
+- provide a concise, mobile-friendly summary of conditions
+- use emoji and formatting that renders well in Telegram clients
+
+## Public Entry Points
+
+- [`format-telegram.ts`](./format-telegram.ts)
+  `formatTelegram(input)` — Main entry point. Accepts `BriefRenderInput` and returns an HTML-formatted string for Telegram.
+
+Exported types (re-exports from brief types):
+```typescript
+export type {
+  AltLocation, CarWash, DarkSkyAlertCard, DaySummary,
+  LongRangeCard, Window, WindowHour,
+} from '../../types/brief.js';
+
+export type FormatTelegramInput = BriefRenderInput;
+```
+
+## Main Files / Module Map
+
+- `format-telegram.ts`
+  Single-file presenter with helper functions and main export. Organized into:
+  - Helper functions for specific sections (alternatives, windows, 5-day forecast, car wash, long range)
+  - Main `formatTelegram()` function that assembles the complete message
+
+### Helper Functions
+
+- `altsTelegram(alts)` — Formats alternative locations with emoji indicators
+- `windowsTelegram(wins)` — Formats shooting windows with weather details
+- `photoFiveDayTelegram(days)` — Formats 4-day photo forecast with bar charts
+- `cwFiveDayTelegram(days)` — Formats car wash forecast
+- `longRangeTelegram(top, label, alert)` — Formats long-range destination section
+
+## Data In / Data Out
+
+**Input (`FormatTelegramInput` / `BriefRenderInput`):**
+```typescript
+{
+  dontBother: boolean
+  windows: Window[]
+  dailySummary: DaySummary[]
+  altLocations: AltLocation[]
+  aiText: string
+  sunriseStr: string
+  sunsetStr: string
+  moonPct: number
+  peakKpTonight: number | null
+  longRangeTop: LongRangeCard | null
+  // ... (see ../../types/brief.ts for complete type)
+}
+```
+
+**Output:**
+HTML-formatted string using Telegram's allowed tags:
+- `<b>` — bold
+- `<i>` — italic
+- `<code>` — monospace (used for aligned tables)
+- Emoji characters for visual indicators
+
+## Telegram HTML Constraints
+
+Telegram supports a limited HTML subset. This formatter uses:
+- `<b>` for bold headers and emphasis
+- `<i>` for italic hints and secondary text
+- `<code>` for monospace alignment (forecast tables)
+- Unicode emoji for visual indicators (📷, 🔥, 🌅, 🌙, etc.)
+
+**Not supported** (and not used):
+- `<br>` (use `\n` instead)
+- CSS styles
+- Nested tags beyond simple combinations
+
+## What Belongs Here
+
+- Telegram-specific message formatting
+- Emoji selection and placement
+- Concise summary logic (mobile-optimized)
+- Telegram HTML tag usage
+- Character-efficient formatting
+
+## What Does Not Belong Here
+
+- **Full HTML documents** — belongs in `../site/`
+- **Email markup** — belongs in `../email/`
+- **Business logic** — belongs in `src/domain`
+- **Shared formatting** — use `../shared/brief-primitives.ts` for colors/icons if needed
+
+## Tests
+
+Tests for Telegram formatting are typically covered via integration tests in the adapter layer:
+- [`../../adapters/n8n/format-messages.adapter.test.ts`](../../adapters/n8n/format-messages.adapter.test.ts)
+
+## Working Rule
+
+Keep Telegram output concise and scannable. Mobile users need to glance and understand conditions quickly. Use emoji for visual scanning, monospace tables for alignment, and bold for key information. The "don't bother" state should be immediately obvious from the first line.
+
+## Output Structure
+
+The formatted message follows this structure:
+
+```
+📷 {Location} Photo Brief — {Date}
+🌅 {sunrise}  🌇 {sunset}  🌙 {moon}% moon
+{hue/aurora lines if applicable}
+───────────────────────
+{windows or "Not worth it today"}
+
+💬 {AI editorial text}
+
+📍 Other places to consider today:
+{alternatives list}
+
+───────────────────────
+📅 Days Ahead
+{4-day forecast table}
+
+🚗 Car Wash Forecast
+{car wash table}
+```
+
+## Related Docs
+
+- [`../email/README.md`](../email/README.md) — Email presenter (similar input, different output)
+- [`../site/README.md`](../site/README.md) — Site presenter (full HTML output)
+- [`../../adapters/n8n/README.md`](../../adapters/n8n/README.md) — How Telegram messages are sent via n8n


### PR DESCRIPTION
## Summary

This PR completes the documentation coverage across all major architecture layers as specified in #114.

## New Documentation Files

| File | Purpose |
|------|---------|
|  | App layer orchestration primer |
|  | Main use case documentation |
|  | Domain layer overview (scoring + editorial) |
|  | Presenter layer overview |
|  | Site presenter primer |
|  | Telegram presenter primer |
|  | Brief JSON primer |
|  | Shared primitives primer |

## Updated Documentation

| File | Changes |
|------|---------|
|  | Added plain-English summary, 'where to make changes' table, 'new contributors start here' section, links to all primers |
|  | Added data flow diagram, runtime vs build-time explanation, n8n integration details, path to running without n8n, contracts vs types guidance |

## Documentation Template

Each new README follows the recommended template:
- **Purpose** — What this layer/folder does
- **Public entry points** — Stable seams for external callers
- **Main files / module map** — Key files and their roles
- **Data in / data out** — Input/output contracts
- **What belongs here** — Inclusion criteria
- **What does not belong here** — Exclusion criteria with pointers to correct locations
- **Tests** — Test file locations
- **Working rule** — Guiding principle for contributors
- **Related docs** — Links to related documentation

## Acceptance Criteria

- [x] Root-level documentation spine:  + 
- [x] Every major architecture layer has a local primer
- [x] Every major presenter/output folder has a local primer
- [x] App layer and main use case documented
- [x] Contracts vs types documented
- [x] n8n integration explained without making it feel core
- [x] New contributor/agent can navigate and identify where to place changes

Closes #114