### PR TITLE
refactor: move toScoredForecastContext mapper from adapters to app layer

### DIFF
--- a/src/adapters/n8n/render-outputs.ts
+++ b/src/adapters/n8n/render-outputs.ts
@@ -7,7 +7,7 @@ import type {
   FormatMessagesOutput,
   RenderableRuntimeContext,
 } from './contracts/final-runtime-payload.js';
-import { toScoredForecastContext } from './mappers/to-scored-forecast.js';
+import { toScoredForecastContext } from '../../app/run-photo-brief/mappers/to-scored-forecast.js';
 
 export function renderOutputs(
   ctx: RenderableRuntimeContext,

--- a/src/app/run-photo-brief/finalize-brief.ts
+++ b/src/app/run-photo-brief/finalize-brief.ts
@@ -26,7 +26,7 @@ import { formatSite } from '../../presenters/site/format-site.js';
 import { formatTelegram } from '../../presenters/telegram/format-telegram.js';
 import { formatDebugEmail, formatEmail } from '../../presenters/email/index.js';
 import { renderBriefAsJson } from '../../presenters/brief-json/render-brief-json.js';
-import { toScoredForecastContext } from '../../adapters/n8n/mappers/to-scored-forecast.js';
+import { toScoredForecastContext } from './mappers/to-scored-forecast.js';
 import type {
   BriefContext,
   LongRangeSpurCandidate,

--- a/src/app/run-photo-brief/mappers/to-scored-forecast.ts
+++ b/src/app/run-photo-brief/mappers/to-scored-forecast.ts
@@ -13,7 +13,7 @@ import type {
   DarkSkyAlertCard,
   SessionRecommendationSummary,
 } from '../../../contracts/index.js';
-import type { RenderableRuntimeContext } from '../contracts/final-runtime-payload.js';
+import type { RenderableRuntimeContext } from '../../../adapters/n8n/contracts/final-runtime-payload.js';
 import type { AuroraSignal } from '../../../lib/aurora-providers.js';
 
 /**


### PR DESCRIPTION
## Summary

Moves the `toScoredForecastContext` mapper from `src/adapters/n8n/mappers/` to `src/app/run-photo-brief/mappers/` to eliminate the unwanted dependency from app layer to adapter layer.

## Changes

- **Moved** `src/adapters/n8n/mappers/to-scored-forecast.ts` → `src/app/run-photo-brief/mappers/to-scored-forecast.ts`
- **Updated** `src/app/run-photo-brief/finalize-brief.ts` to import from the new local location (`./mappers/to-scored-forecast.js`)
- **Updated** `src/adapters/n8n/render-outputs.ts` to import from the app layer (`../../app/run-photo-brief/mappers/to-scored-forecast.js`)

## Architecture Impact

This change enforces the architecture principle that the **app layer should not depend on adapters**. The mapper converts from `RenderableRuntimeContext` (n8n-specific type) to `ScoredForecastContext` (contract type). Since this is input normalization for the app layer's use case, it belongs with the app layer that consumes it.

The remaining import from adapters in the mapper is a **type-only import** for `RenderableRuntimeContext`, which defines the input boundary from n8n. This is acceptable as it's a type definition, not a runtime dependency.

## Verification

- [x] All 415 tests pass
- [x] Build succeeds without errors
- [x] No runtime imports from `src/adapters/**` in `src/app/**` code

## Related Issue

Fixes #125