### PR TITLE
feat: Add golden fixtures for finalizeBrief editorial testing (#169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ Aperture fetches weather forecast data from multiple providers (Open-Meteo, Open
 - `npm run typecheck`
 - `npm run build`
 
+## Testing
+
+### Golden Fixtures
+
+The project uses **golden fixtures** for deterministic testing of AI-dependent components:
+
+```bash
+# Run golden fixture tests for finalizeBrief
+npm test -- finalize-brief.golden-fixtures.test.ts
+```
+
+Golden fixtures are located in `fixtures/golden/` and provide:
+- Deterministic test data (no external API calls)
+- Coverage of happy paths, edge cases, and failure modes
+- Baseline assertions for AI provider selection and fallback behavior
+
+See [`fixtures/golden/README.md`](./fixtures/golden/README.md) for details on available fixtures and when to update them.
+
 ## Development Setup
 
 **⚠️ Important: You must run `npm run build` before `npm run typecheck`**

--- a/fixtures/golden/README.md
+++ b/fixtures/golden/README.md
@@ -1,0 +1,60 @@
+# Golden Fixtures
+
+Golden fixtures provide baseline test data for the `finalizeBrief` editorial generation function. These fixtures serve as the source of truth for expected behavior across different AI provider scenarios.
+
+## What Are Golden Fixtures?
+
+Golden fixtures are JSON files containing predefined inputs and expected AI responses. They allow tests to run deterministically without making actual API calls to Groq or Gemini. Each fixture represents a specific scenario that the editorial system must handle correctly.
+
+## Fixture Scenarios
+
+| Fixture | Description | Expected Behavior |
+|---------|-------------|-------------------|
+| `good-local-window.json` | Happy path - local conditions are good (78/100 score) | Groq selected, no fallback needed |
+| `dont-bother.json` | Poor conditions - dontBother flag set, low scores (32/100) | Groq selected, alt locations suggested |
+| `groq-succeeds-gemini-empty.json` | Primary provider works, secondary empty | Groq selected, Gemini ignored |
+| `groq-malformed-gemini-usable.json` | Primary fails (malformed JSON), secondary works | Model fallback to Gemini |
+| `both-fail-template-fallback.json` | Both AI providers fail | Template fallback used |
+
+## Fixture Structure
+
+Each fixture contains:
+
+```json
+{
+  "_comment": "Description of the scenario",
+  "scenario": "fixture-name",
+  "description": "Human-readable description",
+  "context": { /* Weather data, windows, alt locations, sun/moon times */ },
+  "groqChoices": [ /* Simulated Groq API response */ ],
+  "geminiResponse": "Simulated Gemini response string",
+  "homeLocation": { /* Location config */ },
+  "debug": { /* Debug settings */ },
+  "preferredProvider": "groq"
+}
+```
+
+## Running the Tests
+
+The golden fixture tests are in:
+```
+src/app/run-photo-brief/finalize-brief.golden-fixtures.test.ts
+```
+
+Run with:
+```bash
+npm test -- finalize-brief.golden-fixtures.test.ts
+```
+
+## When to Update Fixtures
+
+- **New scenarios**: Add a fixture when a new edge case is discovered
+- **Behavior changes**: Update fixtures when expected behavior changes intentionally
+- **Provider updates**: Update mock responses when AI provider formats change
+
+## Golden Fixture Philosophy
+
+1. **Deterministic**: Fixtures produce the same result every time
+2. **Isolated**: No external API calls during test execution
+3. **Documented**: Each fixture clearly describes its purpose
+4. **Comprehensive**: Cover happy path, edge cases, and failure modes

--- a/fixtures/golden/both-fail-template-fallback.json
+++ b/fixtures/golden/both-fail-template-fallback.json
@@ -1,0 +1,83 @@
+{
+  "_comment": "Golden fixture: Both providers fail - template fallback used",
+  "scenario": "both-fail-template-fallback",
+  "description": "Both Groq and Gemini return empty/invalid - should use deterministic template fallback",
+  "context": {
+    "dontBother": false,
+    "windows": [
+      {
+        "label": "Evening session",
+        "start": "17:00",
+        "end": "19:00",
+        "peak": 58,
+        "peakHour": "18:00",
+        "tops": ["mixed clouds"],
+        "hours": [
+          { "hour": "17:00", "score": 52, "ct": 40, "visK": 10, "aod": 0.18 },
+          { "hour": "18:00", "score": 58, "ct": 35, "visK": 12, "aod": 0.15 },
+          { "hour": "19:00", "score": 55, "ct": 38, "visK": 11, "aod": 0.16 }
+        ]
+      }
+    ],
+    "dailySummary": [
+      {
+        "dayLabel": "Today",
+        "dayIdx": 0,
+        "headlineScore": 58,
+        "photoScore": 58,
+        "confidence": "low",
+        "confidenceStdDev": 10,
+        "bestPhotoHour": "18:00",
+        "astroScore": 30,
+        "bestAstroHour": null,
+        "darkSkyStartsAt": "21:30"
+      }
+    ],
+    "altLocations": [
+      {
+        "name": "Yorkshire Dales",
+        "bestScore": 72,
+        "bestAstroHour": null,
+        "darkSky": true,
+        "driveMins": 60
+      }
+    ],
+    "today": "Tuesday 7 April",
+    "todayBestScore": 58,
+    "peakKpTonight": 4.0,
+    "auroraSignal": null,
+    "sunriseStr": "06:05",
+    "sunsetStr": "19:55",
+    "moonPct": 65,
+    "metarNote": "",
+    "todayCarWash": {
+      "rating": "Fair",
+      "label": "Fair conditions",
+      "score": 55,
+      "start": "12:00",
+      "end": "18:00",
+      "wind": 18,
+      "pp": 30,
+      "tmp": 13
+    }
+  },
+  "groqChoices": [
+    {
+      "message": {
+        "content": ""
+      }
+    }
+  ],
+  "geminiResponse": "",
+  "homeLocation": {
+    "name": "Leeds",
+    "lat": 53.8008,
+    "lon": -1.5491,
+    "timezone": "Europe/London"
+  },
+  "debug": {
+    "enabled": false,
+    "emailTo": ""
+  },
+  "preferredProvider": "groq"
+}

--- a/fixtures/golden/dont-bother.json
+++ b/fixtures/golden/dont-bother.json
@@ -1,0 +1,76 @@
+{
+  "_comment": "Golden fixture: Dont-bother day - poor conditions with low scores",
+  "scenario": "dont-bother",
+  "description": "Conditions are poor (dontBother=true) with no good local windows",
+  "context": {
+    "dontBother": true,
+    "windows": [],
+    "dailySummary": [
+      {
+        "dayLabel": "Today",
+        "dayIdx": 0,
+        "headlineScore": 32,
+        "photoScore": 32,
+        "confidence": "low",
+        "confidenceStdDev": 12,
+        "bestPhotoHour": "14:00",
+        "astroScore": 25,
+        "bestAstroHour": null,
+        "darkSkyStartsAt": null
+      }
+    ],
+    "altLocations": [
+      {
+        "name": "Sutton Bank",
+        "bestScore": 68,
+        "bestAstroHour": null,
+        "darkSky": true,
+        "driveMins": 75
+      },
+      {
+        "name": "Malham Cove",
+        "bestScore": 62,
+        "bestAstroHour": null,
+        "darkSky": true,
+        "driveMins": 55
+      }
+    ],
+    "today": "Saturday 4 April",
+    "todayBestScore": 32,
+    "peakKpTonight": 2.0,
+    "auroraSignal": null,
+    "sunriseStr": "06:12",
+    "sunsetStr": "19:47",
+    "moonPct": 35,
+    "metarNote": "Low cloud base, intermittent rain",
+    "todayCarWash": {
+      "rating": "Poor",
+      "label": "Poor conditions - wait for better weather",
+      "score": 25,
+      "start": null,
+      "end": null,
+      "wind": 25,
+      "pp": 80,
+      "tmp": 12
+    }
+  },
+  "groqChoices": [
+    {
+      "message": {
+        "content": "{\"editorial\": \"Leeds looks poor for photography today with overcast skies and intermittent rain. Conditions remain marginal throughout the day.\", \"composition\": [], \"weekStandout\": \"\"}"
+      }
+    }
+  ],
+  "geminiResponse": "",
+  "homeLocation": {
+    "name": "Leeds",
+    "lat": 53.8008,
+    "lon": -1.5491,
+    "timezone": "Europe/London"
+  },
+  "debug": {
+    "enabled": false,
+    "emailTo": ""
+  },
+  "preferredProvider": "groq"
+}

--- a/fixtures/golden/good-local-window.json
+++ b/fixtures/golden/good-local-window.json
@@ -1,0 +1,82 @@
+{
+  "_comment": "Golden fixture: Good local window day - clear conditions with high scores",
+  "scenario": "good-local-window",
+  "description": "Local conditions are good with a clear evening window scoring 78/100",
+  "context": {
+    "dontBother": false,
+    "windows": [
+      {
+        "label": "Evening golden hour",
+        "start": "18:30",
+        "end": "19:30",
+        "peak": 78,
+        "peakHour": "19:00",
+        "tops": ["golden hour", "clear light path"],
+        "hours": [
+          { "hour": "18:30", "score": 75, "ct": 15, "visK": 10, "aod": 0.1 },
+          { "hour": "19:00", "score": 78, "ct": 10, "visK": 12, "aod": 0.08 }
+        ]
+      }
+    ],
+    "dailySummary": [
+      {
+        "dayLabel": "Today",
+        "dayIdx": 0,
+        "headlineScore": 78,
+        "photoScore": 78,
+        "confidence": "high",
+        "confidenceStdDev": 5,
+        "bestPhotoHour": "19:00",
+        "astroScore": 45,
+        "bestAstroHour": null,
+        "darkSkyStartsAt": null
+      }
+    ],
+    "altLocations": [
+      {
+        "name": "Ilkley Moor",
+        "bestScore": 82,
+        "bestAstroHour": null,
+        "darkSky": false,
+        "driveMins": 25
+      }
+    ],
+    "today": "Friday 3 April",
+    "todayBestScore": 78,
+    "peakKpTonight": 3.5,
+    "auroraSignal": null,
+    "sunriseStr": "06:15",
+    "sunsetStr": "19:45",
+    "moonPct": 25,
+    "metarNote": "",
+    "todayCarWash": {
+      "rating": "Good",
+      "label": "Good conditions",
+      "score": 75,
+      "start": "09:00",
+      "end": "18:00",
+      "wind": 12,
+      "pp": 10,
+      "tmp": 15
+    }
+  },
+  "groqChoices": [
+    {
+      "message": {
+        "content": "{\"editorial\": \"The evening golden hour offers excellent conditions with clear skies and good visibility. The 19:00 peak scores 78/100 with minimal cloud cover, making this the best local window of the day.\", \"composition\": [\"Position yourself facing west for the best sunset light\", \"Use a polarizer to enhance sky colors\"], \"weekStandout\": \"Today stands out for its clear evening conditions.\"}"
+      }
+    }
+  ],
+  "geminiResponse": "",
+  "homeLocation": {
+    "name": "Leeds",
+    "lat": 53.8008,
+    "lon": -1.5491,
+    "timezone": "Europe/London"
+  },
+  "debug": {
+    "enabled": false,
+    "emailTo": ""
+  },
+  "preferredProvider": "groq"
+}

--- a/fixtures/golden/groq-malformed-gemini-usable.json
+++ b/fixtures/golden/groq-malformed-gemini-usable.json
@@ -1,0 +1,75 @@
+{
+  "_comment": "Golden fixture: Groq malformed, Gemini usable - fallback to secondary provider",
+  "scenario": "groq-malformed-gemini-usable",
+  "description": "Groq returns malformed JSON, Gemini returns valid content - should use Gemini",
+  "context": {
+    "dontBother": false,
+    "windows": [
+      {
+        "label": "Morning golden hour",
+        "start": "06:30",
+        "end": "08:00",
+        "peak": 72,
+        "peakHour": "07:00",
+        "tops": ["golden hour", "mist clearing"],
+        "hours": [
+          { "hour": "06:30", "score": 65, "ct": 30, "visK": 8, "aod": 0.2 },
+          { "hour": "07:00", "score": 72, "ct": 20, "visK": 12, "aod": 0.15 },
+          { "hour": "07:30", "score": 68, "ct": 25, "visK": 10, "aod": 0.18 }
+        ]
+      }
+    ],
+    "dailySummary": [
+      {
+        "dayLabel": "Today",
+        "dayIdx": 0,
+        "headlineScore": 72,
+        "photoScore": 72,
+        "confidence": "medium",
+        "confidenceStdDev": 7,
+        "bestPhotoHour": "07:00",
+        "astroScore": 40,
+        "bestAstroHour": null,
+        "darkSkyStartsAt": null
+      }
+    ],
+    "altLocations": [],
+    "today": "Monday 6 April",
+    "todayBestScore": 72,
+    "peakKpTonight": 2.5,
+    "auroraSignal": null,
+    "sunriseStr": "06:08",
+    "sunsetStr": "19:52",
+    "moonPct": 55,
+    "metarNote": "Early mist clearing",
+    "todayCarWash": {
+      "rating": "Good",
+      "label": "Good morning conditions",
+      "score": 70,
+      "start": "07:00",
+      "end": "10:00",
+      "wind": 10,
+      "pp": 15,
+      "tmp": 11
+    }
+  },
+  "groqChoices": [
+    {
+      "message": {
+        "content": "This is not valid JSON { broken: response, missing quotes, trailing comma, }"
+      }
+    }
+  ],
+  "geminiResponse": "{\"editorial\": \"The morning golden hour brings the best conditions today. Mist clears by 07:00 revealing excellent light with 12km visibility and a peak score of 72/100.\", \"composition\": [\"Capture the mist while it lasts in the early hour\", \"Position east-facing for golden sunrise light\"], \"weekStandout\": \"Monday morning offers the clearest window this week.\"}",
+  "homeLocation": {
+    "name": "Leeds",
+    "lat": 53.8008,
+    "lon": -1.5491,
+    "timezone": "Europe/London"
+  },
+  "debug": {
+    "enabled": false,
+    "emailTo": ""
+  },
+  "preferredProvider": "groq"
+}

--- a/fixtures/golden/groq-succeeds-gemini-empty.json
+++ b/fixtures/golden/groq-succeeds-gemini-empty.json
@@ -1,0 +1,75 @@
+{
+  "_comment": "Golden fixture: Groq succeeds, Gemini empty - preferred provider works",
+  "scenario": "groq-succeeds-gemini-empty",
+  "description": "Groq returns valid JSON content, Gemini response is empty string",
+  "context": {
+    "dontBother": false,
+    "windows": [
+      {
+        "label": "Late afternoon",
+        "start": "15:00",
+        "end": "17:00",
+        "peak": 65,
+        "peakHour": "16:00",
+        "tops": ["partly cloudy", "good visibility"],
+        "hours": [
+          { "hour": "15:00", "score": 58, "ct": 25, "visK": 15, "aod": 0.15 },
+          { "hour": "16:00", "score": 65, "ct": 20, "visK": 18, "aod": 0.12 },
+          { "hour": "17:00", "score": 62, "ct": 22, "visK": 16, "aod": 0.14 }
+        ]
+      }
+    ],
+    "dailySummary": [
+      {
+        "dayLabel": "Today",
+        "dayIdx": 0,
+        "headlineScore": 65,
+        "photoScore": 65,
+        "confidence": "medium",
+        "confidenceStdDev": 8,
+        "bestPhotoHour": "16:00",
+        "astroScore": 35,
+        "bestAstroHour": null,
+        "darkSkyStartsAt": null
+      }
+    ],
+    "altLocations": [],
+    "today": "Sunday 5 April",
+    "todayBestScore": 65,
+    "peakKpTonight": 3.0,
+    "auroraSignal": null,
+    "sunriseStr": "06:10",
+    "sunsetStr": "19:50",
+    "moonPct": 45,
+    "metarNote": "",
+    "todayCarWash": {
+      "rating": "Fair",
+      "label": "Fair conditions",
+      "score": 60,
+      "start": "10:00",
+      "end": "17:00",
+      "wind": 15,
+      "pp": 20,
+      "tmp": 14
+    }
+  },
+  "groqChoices": [
+    {
+      "message": {
+        "content": "{\"editorial\": \"The late afternoon offers decent conditions with partly cloudy skies and 16km visibility. The 16:00 hour peaks at 65/100.\", \"composition\": [\"Look for breaks in the cloud for interesting light\"], \"weekStandout\": \"\"}"
+      }
+    }
+  ],
+  "geminiResponse": "",
+  "homeLocation": {
+    "name": "Leeds",
+    "lat": 53.8008,
+    "lon": -1.5491,
+    "timezone": "Europe/London"
+  },
+  "debug": {
+    "enabled": false,
+    "emailTo": ""
+  },
+  "preferredProvider": "groq"
+}

--- a/src/app/run-photo-brief/finalize-brief.golden-fixtures.test.ts
+++ b/src/app/run-photo-brief/finalize-brief.golden-fixtures.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Golden Fixture Tests for finalizeBrief
+ *
+ * These tests provide baseline and guardrails for editorial behavior.
+ * They use fixture files to test specific scenarios and verify:
+ * - final briefJson structure (snapshot-style assertions)
+ * - debug output invariants
+ * - provider selection and fallback behavior
+ *
+ * Part of Phase 0 — Baseline and guardrails (Issue #169)
+ */
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { finalizeBrief } from './finalize-brief.js';
+import type { FinalizeConfig, RawEditorialInput, FinalizeRuntimeContext } from './finalize-brief-contracts.js';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Path to golden fixtures
+const FIXTURES_DIR = join(__dirname, '../../../fixtures/golden');
+
+/**
+ * Load a golden fixture file
+ */
+function loadFixture(name: string): RawEditorialInput & { scenario: string; description: string } {
+  const path = join(FIXTURES_DIR, `${name}.json`);
+  const content = readFileSync(path, 'utf-8');
+  return JSON.parse(content);
+}
+
+/**
+ * Create base config from fixture data
+ */
+function createConfigFromFixture(fixture: RawEditorialInput & { preferredProvider?: string }): FinalizeConfig {
+  return {
+    preferredProvider: fixture.preferredProvider || 'groq',
+    homeLocation: {
+      name: fixture.homeLocation?.name || 'Test Location',
+      lat: fixture.homeLocation?.lat ?? 53.8,
+      lon: fixture.homeLocation?.lon ?? -1.5,
+      timezone: fixture.homeLocation?.timezone || 'Europe/London',
+    },
+    debug: {
+      enabled: fixture.debug?.enabled ?? false,
+      emailTo: fixture.debug?.emailTo || '',
+      source: 'golden-fixture-test',
+    },
+    triggerSource: 'golden-fixture-test',
+  };
+}
+
+describe('Golden Fixtures - finalizeBrief E2E', () => {
+  describe('Scenario: good-local-window', () => {
+    const fixture = loadFixture('good-local-window');
+    const config = createConfigFromFixture(fixture);
+    const result = finalizeBrief(fixture, config);
+
+    it('should produce a valid briefJson with editorial content', () => {
+      expect(result.briefJson).toBeDefined();
+      expect(result.briefJson.aiText).toBeTruthy();
+      expect(result.briefJson.aiText.length).toBeGreaterThan(0);
+    });
+
+    it('should use groq as selected provider (preferred provider succeeded)', () => {
+      expect(result.editorial.selectedProvider).toBe('groq');
+      expect(result.editorial.primaryProvider).toBe('groq');
+    });
+
+    it('should NOT use fallback', () => {
+      expect(result.editorial.fallbackUsed).toBe(false);
+    });
+
+    it('should have composition bullets from AI response', () => {
+      expect(result.briefJson.compositionBullets).toBeDefined();
+      expect(Array.isArray(result.briefJson.compositionBullets)).toBe(true);
+    });
+
+    it('should have week insight present', () => {
+      expect(result.editorial.weekInsight).toBeTruthy();
+      expect(result.editorial.weekInsight.length).toBeGreaterThan(0);
+    });
+
+    it('should have debug context with correct provider info', () => {
+      expect(result.debugContext.ai).toBeDefined();
+      expect(result.debugContext.ai?.selectedProvider).toBe('groq');
+      expect(result.debugContext.ai?.fallbackUsed).toBe(false);
+    });
+
+    it('should have window info in briefJson', () => {
+      expect(result.briefJson.windows).toBeDefined();
+      expect(result.briefJson.windows.length).toBeGreaterThan(0);
+      expect(result.briefJson.windows[0].peak).toBe(78);
+    });
+
+    it('should NOT have dontBother flag set', () => {
+      expect(result.briefJson.dontBother).toBe(false);
+    });
+  });
+
+  describe('Scenario: dont-bother', () => {
+    const fixture = loadFixture('dont-bother');
+    const config = createConfigFromFixture(fixture);
+    const result = finalizeBrief(fixture, config);
+
+    it('should produce a valid briefJson', () => {
+      expect(result.briefJson).toBeDefined();
+    });
+
+    it('should have dontBother flag set', () => {
+      expect(result.briefJson.dontBother).toBe(true);
+    });
+
+    it('should use groq as selected provider', () => {
+      expect(result.editorial.selectedProvider).toBe('groq');
+    });
+
+    it('should NOT use fallback (AI response is valid)', () => {
+      expect(result.editorial.fallbackUsed).toBe(false);
+    });
+
+    it('should include alternative location info in editorial', () => {
+      // Should mention alternative locations since dontBother is true
+      expect(result.editorial.aiText).toBeTruthy();
+    });
+
+    it('should have empty windows array in briefJson', () => {
+      expect(result.briefJson.windows).toBeDefined();
+      expect(result.briefJson.windows.length).toBe(0);
+    });
+
+    it('should have low headline score in context', () => {
+      expect(result.briefJson.headline?.score).toBeLessThan(40);
+    });
+
+    it('should have debug context with fallbackUsed false', () => {
+      expect(result.debugContext.ai?.fallbackUsed).toBe(false);
+    });
+  });
+
+  describe('Scenario: groq-succeeds-gemini-empty', () => {
+    const fixture = loadFixture('groq-succeeds-gemini-empty');
+    const config = createConfigFromFixture(fixture);
+    const result = finalizeBrief(fixture, config);
+
+    it('should produce a valid briefJson with editorial from Groq', () => {
+      expect(result.briefJson).toBeDefined();
+      expect(result.briefJson.aiText).toBeTruthy();
+    });
+
+    it('should use groq as selected provider (gemini empty)', () => {
+      expect(result.editorial.selectedProvider).toBe('groq');
+      expect(result.editorial.primaryProvider).toBe('groq');
+    });
+
+    it('should NOT use fallback (Groq succeeded)', () => {
+      expect(result.editorial.fallbackUsed).toBe(false);
+    });
+
+    it('should have debug context showing gemini response was empty', () => {
+      expect(result.debugContext.ai?.rawGeminiResponse).toBe('');
+    });
+
+    it('should have editorial.aiText derived from Groq response', () => {
+      expect(result.editorial.aiText).toContain('16:00');
+    });
+  });
+
+  describe('Scenario: groq-malformed-gemini-usable', () => {
+    const fixture = loadFixture('groq-malformed-gemini-usable');
+    const config = createConfigFromFixture(fixture);
+    const result = finalizeBrief(fixture, config);
+
+    it('should produce a valid briefJson with editorial content', () => {
+      expect(result.briefJson).toBeDefined();
+      expect(result.briefJson.aiText).toBeTruthy();
+    });
+
+    it('should use gemini as selected provider (model fallback)', () => {
+      // Groq is preferred but malformed, so should fallback to Gemini
+      expect(result.editorial.selectedProvider).toBe('gemini');
+      expect(result.editorial.primaryProvider).toBe('groq');
+    });
+
+    it('should NOT use template fallback (Gemini usable)', () => {
+      expect(result.editorial.fallbackUsed).toBe(false);
+    });
+
+    it('should have modelFallbackUsed in debug trace', () => {
+      expect(result.debugContext.ai?.modelFallbackUsed).toBe(true);
+    });
+
+    it('should have week insight from Gemini response', () => {
+      expect(result.editorial.weekInsight).toContain('Monday morning');
+    });
+
+    it('should have composition bullets from Gemini', () => {
+      expect(result.briefJson.compositionBullets?.length).toBeGreaterThan(0);
+    });
+
+    it('should capture groq rejection reason in debug trace', () => {
+      expect(result.debugContext.ai?.primaryRejectionReason).toBeTruthy();
+    });
+  });
+
+  describe('Scenario: both-fail-template-fallback', () => {
+    const fixture = loadFixture('both-fail-template-fallback');
+    const config = createConfigFromFixture(fixture);
+    const result = finalizeBrief(fixture, config);
+
+    it('should produce a valid briefJson', () => {
+      expect(result.briefJson).toBeDefined();
+    });
+
+    it('should use template as selected provider (both AI failed)', () => {
+      expect(result.editorial.selectedProvider).toBe('template');
+    });
+
+    it('should use fallback (template fallback)', () => {
+      expect(result.editorial.fallbackUsed).toBe(true);
+    });
+
+    it('should have fallback text in editorial.aiText', () => {
+      expect(result.editorial.aiText).toBeTruthy();
+      // Template fallback should mention the window
+      expect(result.editorial.aiText).toContain('evening');
+    });
+
+    it('should have fallbackUsed true in debug trace', () => {
+      expect(result.debugContext.ai?.fallbackUsed).toBe(true);
+    });
+
+    it('should have primaryRejectionReason in debug trace', () => {
+      expect(result.debugContext.ai?.primaryRejectionReason).toBeTruthy();
+    });
+
+    it('should have secondaryRejectionReason in debug trace', () => {
+      expect(result.debugContext.ai?.secondaryRejectionReason).toBeTruthy();
+    });
+
+    it('should still have window info in briefJson', () => {
+      expect(result.briefJson.windows).toBeDefined();
+      expect(result.briefJson.windows.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('Golden Fixtures - Debug Output Invariants', () => {
+  describe('Debug trace structure validation', () => {
+    const fixture = loadFixture('good-local-window');
+    const config = createConfigFromFixture(fixture);
+    const result = finalizeBrief(fixture, config);
+
+    it('should have debugAiTrace with required fields', () => {
+      const trace = result.debugContext.ai;
+      expect(trace).toBeDefined();
+
+      // Provider info
+      expect(trace?.primaryProvider).toBeDefined();
+      expect(trace?.selectedProvider).toBeDefined();
+      expect(['groq', 'gemini', 'template']).toContain(trace?.selectedProvider);
+
+      // Fallback info
+      expect(typeof trace?.fallbackUsed).toBe('boolean');
+      expect(typeof trace?.modelFallbackUsed).toBe('boolean');
+
+      // Check info
+      expect(trace?.factualCheck).toBeDefined();
+      expect(trace?.editorialCheck).toBeDefined();
+      expect(typeof trace?.factualCheck?.passed).toBe('boolean');
+      expect(Array.isArray(trace?.factualCheck?.rulesTriggered)).toBe(true);
+
+      // Raw responses
+      expect(typeof trace?.rawGroqResponse).toBe('string');
+
+      // Final text
+      expect(typeof trace?.finalAiText).toBe('string');
+    });
+
+    it('should have spurSuggestion debug info', () => {
+      const spur = result.debugContext.ai?.spurSuggestion;
+      expect(spur).toBeDefined();
+      expect(typeof spur?.dropped).toBe('boolean');
+      // raw, confidence, resolved may be null
+    });
+
+    it('should have weekStandout debug info', () => {
+      const weekStandout = result.debugContext.ai?.weekStandout;
+      expect(weekStandout).toBeDefined();
+      expect(weekStandout?.parseStatus).toMatch(/^(present|absent|parse-failure)$/);
+      expect(typeof weekStandout?.used).toBe('boolean');
+    });
+
+    it('should have compositionBullets debug info', () => {
+      const bullets = result.debugContext.ai?.compositionBullets;
+      expect(bullets).toBeDefined();
+      expect(typeof bullets?.rawCount).toBe('number');
+      expect(typeof bullets?.resolvedCount).toBe('number');
+      expect(Array.isArray(bullets?.resolved)).toBe(true);
+    });
+  });
+
+  describe('Week insight presence/absence detection', () => {
+    it('should detect week insight present when groq provides it', () => {
+      const fixture = loadFixture('good-local-window');
+      const config = createConfigFromFixture(fixture);
+      const result = finalizeBrief(fixture, config);
+
+      expect(result.editorial.weekInsight).toBeTruthy();
+      expect(result.debugContext.ai?.weekStandout?.parseStatus).toBe('present');
+      expect(result.debugContext.ai?.weekStandout?.used).toBe(true);
+    });
+
+    it('should handle week insight absence', () => {
+      const fixture = loadFixture('groq-succeeds-gemini-empty');
+      const config = createConfigFromFixture(fixture);
+      const result = finalizeBrief(fixture, config);
+
+      // Empty weekStandout should be handled gracefully
+      expect(result.debugContext.ai?.weekStandout).toBeDefined();
+    });
+  });
+
+  describe('Spur dropped/kept detection', () => {
+    it('should track spur suggestion status in debug trace', () => {
+      const fixture = loadFixture('good-local-window');
+      const config = createConfigFromFixture(fixture);
+      const result = finalizeBrief(fixture, config);
+
+      const spur = result.debugContext.ai?.spurSuggestion;
+      expect(spur).toBeDefined();
+      expect(typeof spur?.dropped).toBe('boolean');
+      // dropReason should be present when dropped
+      if (spur?.dropped) {
+        expect(spur?.dropReason).toBeDefined();
+      }
+    });
+  });
+});
+
+describe('Golden Fixtures - briefJson Snapshot Assertions', () => {
+  describe('briefJson structure validation', () => {
+    const fixture = loadFixture('good-local-window');
+    const config = createConfigFromFixture(fixture);
+    const result = finalizeBrief(fixture, config);
+    const json = result.briefJson;
+
+    it('should have all required top-level fields', () => {
+      expect(json.headline).toBeDefined();
+      expect(json.windows).toBeDefined();
+      expect(json.altLocations).toBeDefined();
+      expect(json.aiText).toBeDefined();
+      expect(json.compositionBullets).toBeDefined();
+      expect(json.spurOfTheMoment).toBeDefined();
+      expect(json.weekInsight).toBeDefined();
+      expect(json.dontBother).toBeDefined();
+      expect(json.sunTimes).toBeDefined();
+      expect(json.moon).toBeDefined();
+      expect(json.carWash).toBeDefined();
+      expect(json.location).toBeDefined();
+      expect(json.generatedAt).toBeDefined();
+    });
+
+    it('should have correct headline structure', () => {
+      expect(json.headline?.score).toBe(78);
+      expect(json.headline?.label).toBeDefined();
+      expect(json.headline?.emoji).toBeDefined();
+    });
+
+    it('should have correct window structure', () => {
+      expect(json.windows.length).toBeGreaterThan(0);
+      const window = json.windows[0];
+      expect(window.label).toBe('Evening golden hour');
+      expect(window.start).toBe('18:30');
+      expect(window.end).toBe('19:30');
+      expect(window.peak).toBe(78);
+      expect(Array.isArray(window.hours)).toBe(true);
+    });
+
+    it('should have correct altLocations structure', () => {
+      expect(json.altLocations.length).toBeGreaterThan(0);
+      const alt = json.altLocations[0];
+      expect(alt.name).toBe('Ilkley Moor');
+      expect(alt.score).toBe(82);
+      expect(alt.driveMins).toBe(25);
+    });
+
+    it('should have correct sunTimes structure', () => {
+      expect(json.sunTimes?.sunrise).toBe('06:15');
+      expect(json.sunTimes?.sunset).toBe('19:45');
+    });
+
+    it('should have correct moon structure', () => {
+      expect(json.moon?.illuminationPct).toBeDefined();
+      expect(json.moon?.phase).toBeDefined();
+    });
+  });
+
+  describe('briefJson for dont-bother scenario', () => {
+    const fixture = loadFixture('dont-bother');
+    const config = createConfigFromFixture(fixture);
+    const result = finalizeBrief(fixture, config);
+    const json = result.briefJson;
+
+    it('should have dontBother flag set', () => {
+      expect(json.dontBother).toBe(true);
+    });
+
+    it('should have alternative location suggestions', () => {
+      expect(json.altLocations.length).toBeGreaterThan(0);
+    });
+
+    it('should have empty or minimal windows', () => {
+      expect(json.windows.length).toBe(0);
+    });
+
+    it('should have low headline score', () => {
+      expect(json.headline?.score).toBeLessThan(40);
+    });
+  });
+});
+
+describe('Golden Fixtures - Provider Selection Matrix', () => {
+  const scenarios = [
+    { name: 'good-local-window', expectedProvider: 'groq', fallbackUsed: false },
+    { name: 'dont-bother', expectedProvider: 'groq', fallbackUsed: false },
+    { name: 'groq-succeeds-gemini-empty', expectedProvider: 'groq', fallbackUsed: false },
+    { name: 'groq-malformed-gemini-usable', expectedProvider: 'gemini', fallbackUsed: false },
+    { name: 'both-fail-template-fallback', expectedProvider: 'template', fallbackUsed: true },
+  ] as const;
+
+  scenarios.forEach(({ name, expectedProvider, fallbackUsed }) => {
+    describe(`Scenario: ${name}`, () => {
+      const fixture = loadFixture(name);
+      const config = createConfigFromFixture(fixture);
+      const result = finalizeBrief(fixture, config);
+
+      it(`should select provider: ${expectedProvider}`, () => {
+        expect(result.editorial.selectedProvider).toBe(expectedProvider);
+      });
+
+      it(`should have fallbackUsed: ${fallbackUsed}`, () => {
+        expect(result.editorial.fallbackUsed).toBe(fallbackUsed);
+      });
+
+      it('should have matching debug trace values', () => {
+        expect(result.debugContext.ai?.selectedProvider).toBe(expectedProvider);
+        expect(result.debugContext.ai?.fallbackUsed).toBe(fallbackUsed);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements Phase 0 baseline and guardrails for the editorial system by adding **golden fixtures** for deterministic testing of `finalizeBrief`.

Closes #169

## Changes

### Golden Fixtures (5 scenarios)

| Fixture | Scenario | Purpose |
|---------|----------|---------|
| `good-local-window.json` | Happy path | Local conditions good (78/100), Groq succeeds |
| `dont-bother.json` | Poor conditions | dontBother=true, low scores (32/100), alt locations suggested |
| `groq-succeeds-gemini-empty.json` | Primary provider works | Groq returns valid JSON, Gemini empty |
| `groq-malformed-gemini-usable.json` | Model fallback | Groq malformed, Gemini usable - tests fallback to secondary |
| `both-fail-template-fallback.json` | Full fallback | Both AI fail - tests deterministic template fallback |

### Test Suite
- 68 tests covering E2E scenarios, debug output invariants, briefJson assertions, and provider selection matrix
- Tests run deterministically without external API calls

### Documentation
- Added `fixtures/golden/README.md` explaining fixture philosophy and usage
- Updated main `README.md` with Testing section referencing golden fixtures

## Testing

```bash
npm test -- finalize-brief.golden-fixtures.test.ts
```

Note: Some tests currently fail because the implementation doesn't yet match the fixture expectations. The fixtures serve as the **golden reference** for what the implementation should produce. Implementation fixes will follow in subsequent PRs.

## Checklist

- [x] Golden fixtures created for all 5 scenarios
- [x] Test suite added with comprehensive assertions
- [x] README updated with testing documentation
- [x] Golden fixtures README added