### PR TITLE
Phase 1: Extract shared prompt parts (closes #163)

### DIFF
--- a/src/domain/README.md
+++ b/src/domain/README.md
@@ -48,6 +48,9 @@ This folder contains the business logic for weather scoring and editorial genera
 - `prompt/build-prompt.ts`
   Builds the AI provider prompt from scored forecast context.
 
+- `prompt/sections/prompt-blocks.ts`
+  Shared prompt block builders for response contracts, spur instructions, and week standout text.
+
 - `resolution/resolve-editorial.ts`
   Orchestrates provider choice, response validation, fallback selection, and debug trace output.
 

--- a/src/domain/editorial/README.md
+++ b/src/domain/editorial/README.md
@@ -22,11 +22,12 @@ This folder owns prompt assembly and editorial resolution for the photography br
 ## Flow
 
 1. Prompt construction happens in [`prompt/build-prompt.ts`](./prompt/build-prompt.ts).
-2. Provider JSON/text parsing happens in [`resolution/parse.ts`](./resolution/parse.ts).
-3. Factual/editorial checks live in [`resolution/validation.ts`](./resolution/validation.ts).
-4. Composition filtering lives in [`resolution/composition.ts`](./resolution/composition.ts).
-5. Week-standout and spur logic live in [`resolution/week-standout.ts`](./resolution/week-standout.ts) and [`resolution/spur-suggestion.ts`](./resolution/spur-suggestion.ts).
-6. [`resolution/resolve-editorial.ts`](./resolution/resolve-editorial.ts) orchestrates those pieces and produces the final editorial decision.
+2. Shared prompt blocks (response contract, spur instructions, week standout) live in [`prompt/sections/prompt-blocks.ts`](./prompt/sections/prompt-blocks.ts) and [`prompt/sections/week-standout.ts`](./prompt/sections/week-standout.ts).
+3. Provider JSON/text parsing happens in [`resolution/parse.ts`](./resolution/parse.ts).
+4. Factual/editorial checks live in [`resolution/validation.ts`](./resolution/validation.ts).
+5. Composition filtering lives in [`resolution/composition.ts`](./resolution/composition.ts).
+6. Week-standout and spur logic live in [`resolution/week-standout.ts`](./resolution/week-standout.ts) and [`resolution/spur-suggestion.ts`](./resolution/spur-suggestion.ts).
+7. [`resolution/resolve-editorial.ts`](./resolution/resolve-editorial.ts) orchestrates those pieces and produces the final editorial decision.
 
 ## What not to edit casually
 

--- a/src/domain/editorial/prompt/sections/dont-bother-prompt.ts
+++ b/src/domain/editorial/prompt/sections/dont-bother-prompt.ts
@@ -2,7 +2,11 @@ import { LONG_RANGE_LOCATIONS } from '../../../../lib/long-range-locations.js';
 import type { AltLocationResult } from '../build-prompt.js';
 import type { DailySummary } from '../../../windowing/best-windows.js';
 import { topAlternativeLine } from './alternatives.js';
-import { weekStandoutSchemaHint, weekStandoutInstructionBlock } from './week-standout.js';
+import {
+  buildEditorialResponseContractText,
+  buildSpurInstructions,
+  buildWeekStandoutInstructions,
+} from './prompt-blocks.js';
 
 const SPUR_LOCATION_NAMES = LONG_RANGE_LOCATIONS.map(l => l.name).join(', ');
 
@@ -29,16 +33,20 @@ export function buildDontBotherPrompt(p: DontBotherPromptParams): string {
     ? ` ${p.homeLocationName} may show some theoretical astro potential (${p.todayDay?.astroScore}/100 raw), but no local window cleared the full weighted threshold.`
     : '';
 
+  const responseContract = buildEditorialResponseContractText({
+    homeLocationName: p.homeLocationName,
+    variant: 'dont-bother',
+    maxWords: 45,
+  });
+
   return `Photography assistant for ${p.homeLocationName}. Today is poor (score: ${p.todayBestScore}/100).
-Respond with ONLY a raw JSON object — no markdown, no code fences:
-{"editorial":"<exactly 2 sentences, max 45 words — sentence 1: why ${p.homeLocationName} is not worth it today; sentence 2: best nearby alternative if provided>","composition":[],"weekStandout":"${weekStandoutSchemaHint()}","spurOfTheMoment":{"locationName":"<exact name from list>","hookLine":"<1 sentence ≤25 words>","confidence":<0.0-1.0>}}
+${responseContract}
 
 Do not include camera tips, composition advice, filler, hype, or emojis in the editorial.
 ${p.seasonalNote ? `Seasonal context: ${p.seasonalNote}\n` : ''}${p.auroraNote ? `${p.auroraNote}\n` : ''}${p.shInfo}${p.moonNote}${p.confNote}${lhStr}${noWindowNote}
 5-day outlook: ${p.weekLine}
 
-${weekStandoutInstructionBlock()}
+${buildWeekStandoutInstructions()}
 
-SPUR OF THE MOMENT — pick one location from this list that would reward a spontaneous drive today given today's season and conditions. Copy the name exactly as shown. hookLine: 1 evocative sentence, ≤25 words, no scores, no drive times, no "${p.homeLocationName}". confidence: 0.7+ only when the fit is clear and specific; omit the spurOfTheMoment key entirely if nothing stands out. Do not pick locations from the 'Nearby alternatives' section.
-Locations: ${SPUR_LOCATION_NAMES}`;
+${buildSpurInstructions({ homeLocationName: p.homeLocationName, locationList: SPUR_LOCATION_NAMES })}`;
 }

--- a/src/domain/editorial/prompt/sections/local-window-prompt.ts
+++ b/src/domain/editorial/prompt/sections/local-window-prompt.ts
@@ -4,9 +4,13 @@ import type { Window, DailySummary } from '../../../windowing/best-windows.js';
 import type { AltLocationResult } from '../build-prompt.js';
 import type { SessionRecommendationSummary } from '../../../../types/session-score.js';
 import { alternativePromptSection } from './alternatives.js';
-import { weekStandoutSchemaHint, weekStandoutInstructionBlock } from './week-standout.js';
 import { isAstroWindow, windowRange, windowTrendInsight } from './shared.js';
 import { skyQualityConstraints } from './sky-quality-constraints.js';
+import {
+  buildEditorialResponseContractText,
+  buildSpurInstructions,
+  buildWeekStandoutInstructions,
+} from './prompt-blocks.js';
 
 const SPUR_LOCATION_NAMES = LONG_RANGE_LOCATIONS.map(l => l.name).join(', ');
 
@@ -117,9 +121,13 @@ export function buildLocalWindowPrompt(p: LocalWindowPromptParams): string {
     ].filter(Boolean).join('\n')}`
     : '';
 
+  const responseContract = buildEditorialResponseContractText({
+    homeLocationName,
+    variant: 'local-window',
+  });
+
   return `You are an expert landscape and astrophotography assistant giving a daily photography briefing for ${homeLocationName}.
-Respond with ONLY a raw JSON object — no markdown, no code fences:
-{"editorial":"<2 sentences max 55 words>","composition":["<shot idea 1>","<shot idea 2>"],"weekStandout":"${weekStandoutSchemaHint()}","spurOfTheMoment":{"locationName":"<exact name from list>","hookLine":"<1 sentence ≤25 words>","confidence":<0.0-1.0>}}
+${responseContract}
 
 EDITORIAL (exactly 2 sentences, max 55 words total):
 Selected primary window: ${bestWin.label} (${windowRange(bestWin)}). Your editorial must reference this window by name or time range. Do not describe conditions outside this window unless making a direct comparison.
@@ -134,10 +142,9 @@ COMPOSITION (2 short bullet items):
 Suggest 2 concrete shot ideas for the best window. Each must name a specific subject or foreground candidate plus a framing cue, direction, or technique suited to these conditions.
 Avoid generic placeholders like "silhouetted landmark foreground" or "wide-field constellation framing" unless the supplied constraints explicitly support them.
 ${shotConstraints ? `\n${shotConstraints}\n` : ''}
-${weekStandoutInstructionBlock()}
+${buildWeekStandoutInstructions()}
 
-SPUR OF THE MOMENT — pick one location from this list that would reward a spontaneous drive today given today's season and conditions. Copy the name exactly as shown. hookLine: 1 evocative sentence, ≤25 words, no scores, no drive times, no "${homeLocationName}". confidence: 0.7+ only when the fit is clear and specific; omit the spurOfTheMoment key entirely if nothing stands out. Do not pick locations from the 'Nearby alternatives' section.
-Locations: ${SPUR_LOCATION_NAMES}
+${buildSpurInstructions({ homeLocationName, locationList: SPUR_LOCATION_NAMES })}
 
 Date: ${today} | Current time: ${nowTimeStr} | Sunrise: ${sunriseStr} | Sunset: ${sunsetStr} | Moon: ${moonPct}%
 ${temporalContext}${seasonalNote ? `Seasonal context: ${seasonalNote}\n` : ''}${auroraNote ? `${auroraNote}\n` : ''}${shInfo}${moonNote}${crepNote}${shQNote}${confNote}${fallbackNote}

--- a/src/domain/editorial/prompt/sections/prompt-blocks.ts
+++ b/src/domain/editorial/prompt/sections/prompt-blocks.ts
@@ -1,0 +1,45 @@
+import {
+  weekStandoutSchemaHint,
+  weekStandoutInstructionBlock,
+  buildWeekStandoutInstructions,
+} from './week-standout.js';
+
+export interface ResponseContractParams {
+  homeLocationName: string;
+  variant: 'local-window' | 'dont-bother';
+  maxWords?: number;
+}
+
+export function buildEditorialResponseContractText(p: ResponseContractParams): string {
+  const { homeLocationName, variant, maxWords = 55 } = p;
+
+  // Build the editorial field based on variant
+  const editorialField = variant === 'local-window'
+    ? '"<2 sentences max 55 words>"'
+    : `"<exactly 2 sentences, max ${maxWords} words — sentence 1: why ${homeLocationName} is not worth it today; sentence 2: best nearby alternative if provided>"`;
+
+  // Build the composition field based on variant
+  const compositionField = variant === 'local-window'
+    ? '["<shot idea 1>","<shot idea 2>"]'
+    : '[]';
+
+  return `Respond with ONLY a raw JSON object — no markdown, no code fences:
+{"editorial":${editorialField},"composition":${compositionField},"weekStandout":"${weekStandoutSchemaHint()}","spurOfTheMoment":{"locationName":"<exact name from list>","hookLine":"<1 sentence ≤25 words>","confidence":<0.0-1.0>}}`;
+}
+
+export interface SpurInstructionsParams {
+  homeLocationName: string;
+  locationList: string;
+}
+
+export function buildSpurInstructions(p: SpurInstructionsParams): string {
+  const { homeLocationName, locationList } = p;
+  return `SPUR OF THE MOMENT — pick one location from this list that would reward a spontaneous drive today given today's season and conditions. Copy the name exactly as shown. hookLine: 1 evocative sentence, ≤25 words, no scores, no drive times, no "${homeLocationName}". confidence: 0.7+ only when the fit is clear and specific; omit the spurOfTheMoment key entirely if nothing stands out. Do not pick locations from the 'Nearby alternatives' section.
+Locations: ${locationList}`;
+}
+
+export {
+  weekStandoutSchemaHint,
+  weekStandoutInstructionBlock,
+  buildWeekStandoutInstructions,
+};

--- a/src/domain/editorial/prompt/sections/week-standout.ts
+++ b/src/domain/editorial/prompt/sections/week-standout.ts
@@ -8,3 +8,11 @@ If one day scores clearly higher than others, call it the "standout" day.
 If today wins only on certainty (lower spread) while another day scores higher, call today the "most reliable" day and briefly name the higher-scoring day with its uncertainty (e.g. "Today is the most reliable forecast; Wednesday may score higher but with much lower certainty").
 Use only the supplied 5-day outlook labels, scores, and spreads. Do not invent a different higher-scoring day.`;
 }
+
+/**
+ * Alias for weekStandoutInstructionBlock to match the naming convention
+ * used by other prompt block builder functions.
+ */
+export function buildWeekStandoutInstructions(): string {
+  return weekStandoutInstructionBlock();
+}


### PR DESCRIPTION
## Summary

This PR extracts shared prompt blocks to reduce duplication and make prompt editing less brittle, as outlined in #163.

## Changes

### New File: `prompt-blocks.ts`
Created shared helper functions:
- `buildEditorialResponseContractText()` - builds JSON response structure
- `buildSpurInstructions()` - builds spur-of-the-moment instructions
- Re-exports week standout functions for unified import

### Updated: `week-standout.ts`
Added `buildWeekStandoutInstructions()` as a naming convention alias for `weekStandoutInstructionBlock()`.

### Refactored: `local-window-prompt.ts`
- Now uses `buildEditorialResponseContractText()` for JSON response structure
- Now uses `buildSpurInstructions()` for spur-of-the-moment section
- Now uses `buildWeekStandoutInstructions()` for week standout block

### Refactored: `dont-bother-prompt.ts`
- Now uses `buildEditorialResponseContractText()` for JSON response structure
- Now uses `buildSpurInstructions()` for spur-of-the-moment section
- Now uses `buildWeekStandoutInstructions()` for week standout block

### Documentation Updates
- Updated `src/domain/editorial/README.md` to reference new prompt-blocks.ts
- Updated `src/domain/README.md` to reference new prompt-blocks.ts

## Verification

- All 13 `build-prompt.test.ts` tests pass
- Prompt wording remains functionally identical (only structure changed)
- No breaking changes to prompt contracts

## Deployment Notes

Safe to deploy immediately after tests are green. Watch for prompt drift only.

## Checklist

- [x] Duplicated prompt prose is centralized
- [x] Prompt files are shorter and more obviously compositional
- [x] All tests pass
- [x] README files updated

Closes #163
