### PR TITLE
fix: update golden fixtures to include required insight keywords

### DIFF
--- a/fixtures/golden/good-local-window.json
+++ b/fixtures/golden/good-local-window.json
@@ -63,7 +63,7 @@
   "groqChoices": [
     {
       "message": {
-        "content": "{\"editorial\": \"The evening golden hour offers excellent conditions with clear skies and good visibility. The 19:00 peak scores 78/100 with minimal cloud cover, making this the best local window of the day.\", \"composition\": [\"Position yourself facing west for the best sunset light\", \"Use a polarizer to enhance sky colors\"], \"weekStandout\": \"Today stands out for its clear evening conditions.\"}"
+        "content": "{\"editorial\": \"The evening golden hour offers excellent conditions because clear skies and good visibility coincide with the best light. The 19:00 peak scores 78/100 with cloud cover clearing and visibility improving to 12km, making this the best local window of the day.\", \"composition\": [\"Position yourself facing west for the best sunset light\", \"Use a polarizer to enhance sky colors\"], \"weekStandout\": \"Today stands out for its clear evening conditions.\"}"
       }
     }
   ],

--- a/fixtures/golden/groq-malformed-gemini-usable.json
+++ b/fixtures/golden/groq-malformed-gemini-usable.json
@@ -60,7 +60,7 @@
       }
     }
   ],
-  "geminiResponse": "{\"editorial\": \"The morning golden hour brings the best conditions today. Mist clears by 07:00 revealing excellent light with 12km visibility and a peak score of 72/100.\", \"composition\": [\"Capture the mist while it lasts in the early hour\", \"Position east-facing for golden sunrise light\"], \"weekStandout\": \"Monday morning offers the clearest window this week.\"}",
+  "geminiResponse": "{\"editorial\": \"The morning golden hour brings the best conditions today because mist is clearing by 07:00, revealing excellent light with 12km visibility and a peak score of 72/100. Expect conditions to improve as the sun rises higher.\", \"composition\": [\"Capture the mist while it lasts in the early hour\", \"Position east-facing for golden sunrise light\"], \"weekStandout\": \"Monday morning offers the clearest window this week.\"}",
   "homeLocation": {
     "name": "Leeds",
     "lat": 53.8008,


### PR DESCRIPTION
## Summary

Fixes 12 of 13 pre-existing golden fixture test failures by updating the AI text to include required insight keywords.

### Problem
The golden fixtures had AI text that was failing the `addsInsight` validation check in `getEditorialCheck()`. The validation requires AI text to contain at least one of 30+ insight keywords (e.g., `because`, `likely`, `improving`, `clearing`, etc.) to ensure the AI adds explanatory content beyond just restating card data.

### Changes

**fixtures/golden/good-local-window.json**
- Before: "The evening golden hour offers excellent conditions with clear skies and good visibility..."
- After: "The evening golden hour offers excellent conditions **because** clear skies and good visibility coincide with the best light... cloud cover **clearing** and visibility **improving** to 12km..."

**fixtures/golden/groq-malformed-gemini-usable.json**
- Before: "The morning golden hour brings the best conditions today. Mist clears by 07:00..."
- After: "The morning golden hour brings the best conditions today **because** mist is **clearing** by 07:00... Expect conditions to **improve**..."

### Results

| Before | After |
|--------|-------|
| 14 failing tests | 1 failing test |
| 13 golden fixture failures | 1 golden fixture failure |

### Remaining Failure

The 1 remaining failure (`should have week insight from Gemini response`) is a **pre-existing issue** unrelated to insight keywords. It's caused by the week standout validation logic replacing the AI's week insight with a fallback. This should be addressed in a separate issue/PR.

### Verification
- [x] All 568 tests run
- [x] 567 tests pass (up from 554)
- [x] Only 1 pre-existing failure remains