### PR TITLE
test: fix golden fixture week insight expectation to match deterministic behavior

### DIFF
--- a/src/app/run-photo-brief/finalize-brief.golden-fixtures.test.ts
+++ b/src/app/run-photo-brief/finalize-brief.golden-fixtures.test.ts
@@ -224,8 +224,10 @@ describe('Golden Fixtures - finalizeBrief E2E', () => {
       expect(result.debugContext.ai?.modelFallbackUsed).toBe(true);
     });
 
-    it('should have week insight from Gemini response', () => {
-      expect(result.editorial.weekInsight).toContain('Monday morning');
+    it('should have deterministic week insight (AI text replaced by deterministic fallback)', () => {
+      // The week standout logic always returns deterministic text, not AI text
+      // See issue #190 - the AI text "Monday morning..." is evaluated but replaced
+      expect(result.editorial.weekInsight).toContain('Today');
     });
 
     it('should have composition bullets from Gemini', () => {


### PR DESCRIPTION
## Summary

Fixes #190 - Updates golden fixture test to match deterministic week standout behavior.

## Problem

The test `should have week insight from Gemini response` expected the raw AI text (`"Monday morning offers the clearest window this week."`) to be preserved in the final output. However, the `resolveWeekStandout()` function in `src/domain/editorial/resolution/week-standout.ts` **always returns deterministic text** rather than the AI text.

## Root Cause

The week standout resolution logic:
1. Evaluates the AI hint for alignment (does it name the correct day?)
2. Always returns deterministic text based on score comparisons
3. Tracks hint alignment in debug but doesn't use AI text for final output

In the fixture scenario:
- AI says: `"Monday morning offers the clearest window this week."`
- System evaluates: `hintAligned: false` (AI says "Monday" not "Today")
- System returns: `"Today is the best bet this week."` (deterministic)

## Solution

Updated the test expectation to match the actual deterministic behavior:
- **Before:** `expect(result.editorial.weekInsight).toContain('Monday morning');`
- **After:** `expect(result.editorial.weekInsight).toContain('Today');`

## Changes

- `src/app/run-photo-brief/finalize-brief.golden-fixtures.test.ts`
  - Updated test name to clarify deterministic behavior
  - Changed assertion to expect deterministic text
  - Added explanatory comment

## Verification

- [x] All 568 tests pass
- [x] Specific scenario `groq-malformed-gemini-usable` now passes
- [x] No changes to production code (test-only fix)

## Related

Fixes #190
