### PR TITLE
fix: correct debug trace diagnostics mapping (#193)

### DIFF
--- a/src/app/run-photo-brief/prepare-debug-context.test.ts
+++ b/src/app/run-photo-brief/prepare-debug-context.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { prepareDebugContext } from './prepare-debug-context.js';
+
+describe('prepareDebugContext', () => {
+  it('returns a trimmed debug mode source when configured', () => {
+    const prepared = prepareDebugContext(
+      { context: {} as never },
+      {
+        preferredProvider: 'groq',
+        homeLocation: {
+          name: 'Leeds',
+          lat: 53.8,
+          lon: -1.55,
+          timezone: 'Europe/London',
+        },
+        debug: {
+          enabled: true,
+          emailTo: 'debug@example.com',
+          source: ' manual-trigger ',
+        },
+        triggerSource: null,
+      },
+    );
+
+    expect(prepared.debugModeSource).toBe('manual-trigger');
+  });
+
+  it('falls back to toggle when the configured source is blank', () => {
+    const prepared = prepareDebugContext(
+      { context: {} as never },
+      {
+        preferredProvider: 'groq',
+        homeLocation: {
+          name: 'Leeds',
+          lat: 53.8,
+          lon: -1.55,
+          timezone: 'Europe/London',
+        },
+        debug: {
+          enabled: true,
+          emailTo: 'debug@example.com',
+          source: '   ',
+        },
+        triggerSource: null,
+      },
+    );
+
+    expect(prepared.debugModeSource).toBe('toggle');
+  });
+});

--- a/src/app/run-photo-brief/prepare-debug-context.ts
+++ b/src/app/run-photo-brief/prepare-debug-context.ts
@@ -34,7 +34,7 @@ export function prepareDebugContext(
   const debugEmailTo = config.debug.emailTo;
   const debugModeSource =
     config.debug.source.trim().length > 0
-      ? config.debug.source
+      ? config.debug.source.trim()
       : debugMode
         ? 'toggle'
         : 'default';

--- a/src/domain/editorial/prompt/build-prompt.test.ts
+++ b/src/domain/editorial/prompt/build-prompt.test.ts
@@ -823,7 +823,7 @@ describe('buildPrompt', () => {
     expect(result.prompt).toContain('Avoid generic placeholders like "silhouetted landmark foreground" or "wide-field constellation framing"');
   });
 
-  it('uses injected home location metadata when provided', () => {
+  it('uses injected home location in the prompt without populating debug metadata', () => {
     const result = buildPrompt({
       homeLocation: {
         name: 'York',
@@ -848,9 +848,7 @@ describe('buildPrompt', () => {
     });
 
     expect(result.prompt).toContain('Photography assistant for York.');
-    expect(result.debugContext.metadata?.location).toBe('York');
-    expect(result.debugContext.metadata?.latitude).toBe(53.96);
-    expect(result.debugContext.metadata?.workflowVersion).toBe('test-workflow-v2');
+    expect(result.debugContext.metadata).toBeUndefined();
   });
 
   it('does not double-apply DST offset for sunrise/sunset strings (regression)', () => {

--- a/src/domain/editorial/prompt/build-prompt.ts
+++ b/src/domain/editorial/prompt/build-prompt.ts
@@ -4,7 +4,6 @@ import { emptyDebugContext, type DebugContext } from '../../../lib/debug-context
 import type { DarkSkyAlert, LongRangeCandidate, LongRangeDebugCandidate } from '../../scoring/score-long-range.js';
 import type { AuroraSignal } from '../../../lib/aurora-providers.js';
 import {
-  DEFAULT_BRIEF_WORKFLOW_VERSION,
   DEFAULT_HOME_LOCATION,
 } from '../../../lib/home-location.js';
 import type {
@@ -89,7 +88,6 @@ export interface BuildPromptOutput extends ScoredForecastContext {
 export function buildPrompt(input: BuildPromptInput): BuildPromptOutput {
   const {
     homeLocation = DEFAULT_HOME_LOCATION,
-    workflowVersion = DEFAULT_BRIEF_WORKFLOW_VERSION,
     windows, dontBother, todayBestScore, todayCarWash,
     dailySummary, altLocations, closeContenders, noAltsMsg, metarNote,
     sessionRecommendation,
@@ -119,18 +117,6 @@ export function buildPrompt(input: BuildPromptInput): BuildPromptOutput {
   const todayDay = dailySummary[0];
   const hasLocalWindow = windows.length > 0;
   const effectiveDontBother = dontBother || !hasLocalWindow;
-
-  debugContext.metadata = {
-    generatedAt: now.toISOString(),
-    location: homeLocation.name,
-    latitude: homeLocation.lat,
-    longitude: homeLocation.lon,
-    timezone: homeLocation.timezone,
-    workflowVersion,
-    debugModeEnabled: false,
-    debugModeSource: null,
-    debugRecipient: null,
-  };
 
   const selectedWindowIsAstro = isAstroWindow(windows[0]);
   let confNote = '';

--- a/src/domain/editorial/resolution/build-debug-trace.test.ts
+++ b/src/domain/editorial/resolution/build-debug-trace.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { buildEditorialGatewayPayload } from '../../../app/run-photo-brief/editorial-gateway.js';
+import { buildDebugAiTrace } from './build-debug-trace.js';
+
+describe('buildDebugAiTrace', () => {
+  it('maps slot-based debug fields from the configured primary provider', () => {
+    const trace = buildDebugAiTrace({
+      selection: {
+        primaryProvider: 'groq',
+        selectedProvider: 'gemini',
+        primaryCandidate: {
+          provider: 'groq',
+          rawContent: 'groq raw',
+          editorial: 'Groq editorial',
+          compositionBullets: ['Groq bullet'],
+          weekInsight: 'Groq week insight',
+          spurRaw: null,
+          parseResult: 'valid-structured',
+          weekStandoutRawValue: 'Groq week insight',
+          normalizedAiText: 'Normalized text',
+          factualCheck: { passed: true, rulesTriggered: [] },
+          editorialCheck: { passed: true, rulesTriggered: [] },
+          passed: false,
+          reusableComponents: true,
+        },
+        secondaryCandidate: {
+          provider: 'gemini',
+          rawContent: 'gemini raw',
+          editorial: 'Gemini editorial',
+          compositionBullets: ['Gemini bullet'],
+          weekInsight: 'Gemini week insight',
+          spurRaw: null,
+          parseResult: 'valid-structured',
+          weekStandoutRawValue: 'Gemini week insight',
+          normalizedAiText: 'Normalized text',
+          factualCheck: { passed: true, rulesTriggered: [] },
+          editorialCheck: { passed: true, rulesTriggered: [] },
+          passed: true,
+          reusableComponents: true,
+        },
+        selectedCandidate: {
+          provider: 'gemini',
+          rawContent: 'gemini raw',
+          editorial: 'Gemini editorial',
+          compositionBullets: ['Gemini bullet'],
+          weekInsight: 'Gemini week insight',
+          spurRaw: null,
+          parseResult: 'valid-structured',
+          weekStandoutRawValue: 'Gemini week insight',
+          normalizedAiText: 'Normalized text',
+          factualCheck: { passed: true, rulesTriggered: [] },
+          editorialCheck: { passed: true, rulesTriggered: [] },
+          passed: true,
+          reusableComponents: true,
+        },
+        componentCandidate: {
+          provider: 'gemini',
+          rawContent: 'gemini raw',
+          editorial: 'Gemini editorial',
+          compositionBullets: ['Gemini bullet'],
+          weekInsight: 'Gemini week insight',
+          spurRaw: null,
+          parseResult: 'valid-structured',
+          weekStandoutRawValue: 'Gemini week insight',
+          normalizedAiText: 'Normalized text',
+          factualCheck: { passed: true, rulesTriggered: [] },
+          editorialCheck: { passed: true, rulesTriggered: [] },
+          passed: true,
+          reusableComponents: true,
+        },
+        fallbackUsed: false,
+      },
+      finalAiText: 'Final AI text',
+      editorialGateway: buildEditorialGatewayPayload({
+        groqRawText: 'groq raw',
+        groqDiagnostics: {
+          statusCode: 503,
+          responseByteLength: 17,
+        },
+        geminiRawText: 'gemini raw',
+        geminiRawPayload: '{"candidates":[]}',
+        geminiDiagnostics: {
+          statusCode: 200,
+          finishReason: 'STOP',
+          candidateCount: 1,
+          responseByteLength: 33,
+          truncated: false,
+        },
+      }),
+      primaryRejectionReason: 'groq rejected',
+      secondaryRejectionReason: null,
+      bestSpurRaw: null,
+      spurOfTheMoment: null,
+      spurDropReason: null,
+      rawCompositionCount: 1,
+      resolvedCompositionBullets: ['Resolved bullet'],
+      weekStandout: {
+        text: 'Today is the best bet this week.',
+        used: true,
+        decision: 'deterministic-used',
+        hintAligned: false,
+        note: 'Used deterministic fallback.',
+      },
+      weekStandoutHintCandidate: {
+        parseResult: 'valid-structured',
+        weekStandoutRawValue: 'Gemini week insight',
+      },
+    });
+
+    expect(trace.rawPrimaryResponse).toBe('groq raw');
+    expect(trace.rawFallbackResponse).toBe('gemini raw');
+    expect(trace.rawPrimaryPayload).toBeUndefined();
+    expect(trace.primaryDiagnostics?.statusCode).toBe(503);
+    expect(trace.fallbackDiagnostics?.statusCode).toBe(200);
+
+    expect(trace.rawGroqResponse).toBe('groq raw');
+    expect(trace.rawGeminiResponse).toBe('gemini raw');
+    expect(trace.rawGeminiPayload).toBe('{"candidates":[]}');
+    expect(trace.geminiDiagnostics?.statusCode).toBe(200);
+    expect(trace.groqDiagnostics?.statusCode).toBe(503);
+    expect(trace.compositionBullets?.resolved).toEqual(['Resolved bullet']);
+  });
+});

--- a/src/domain/editorial/resolution/build-debug-trace.ts
+++ b/src/domain/editorial/resolution/build-debug-trace.ts
@@ -56,7 +56,7 @@ function buildSpurDebugInfo(input: SpurDebugInput): DebugAiTrace['spurSuggestion
 /**
  * Build composition bullets debug information.
  */
-function buildCompositionDebugInfo(input: CompositionDebugInput): { rawCount: number; resolvedCount: number; sourceProvider: string | null; resolved: string[] } {
+function buildCompositionDebugInfo(input: CompositionDebugInput): { rawCount: number; resolvedCount: number; sourceProvider: string | null } {
   const sourceProvider = input.rawCount > 0
     ? (input.componentCandidate?.compositionBullets?.length
         ? input.componentCandidate.provider
@@ -73,7 +73,6 @@ function buildCompositionDebugInfo(input: CompositionDebugInput): { rawCount: nu
     rawCount: input.rawCount,
     resolvedCount: input.resolvedCount,
     sourceProvider: sourceProvider as string | null,
-    resolved: [] as string[], // Will be filled by caller with actual bullets
   };
 }
 
@@ -136,8 +135,15 @@ export interface BuildDebugTraceInput {
  * @returns Complete debug AI trace object
  */
 export function buildDebugAiTrace(input: BuildDebugTraceInput): DebugAiTrace {
-  const primaryDiagnostics = input.editorialGateway.gemini.diagnostics as DebugPrimaryDiagnostics | undefined;
-  const fallbackDiagnostics = input.editorialGateway.groq.diagnostics as DebugFallbackDiagnostics | undefined;
+  const primaryGateway = input.selection.primaryProvider === 'groq'
+    ? input.editorialGateway.groq
+    : input.editorialGateway.gemini;
+  const fallbackGateway = input.selection.primaryProvider === 'groq'
+    ? input.editorialGateway.gemini
+    : input.editorialGateway.groq;
+
+  const primaryDiagnostics = primaryGateway.diagnostics as DebugPrimaryDiagnostics | undefined;
+  const fallbackDiagnostics = fallbackGateway.diagnostics as DebugFallbackDiagnostics | undefined;
   const apiCallStatuses = [
     input.editorialGateway.groq.apiCallStatus,
     input.editorialGateway.gemini.apiCallStatus,
@@ -183,9 +189,11 @@ export function buildDebugAiTrace(input: BuildDebugTraceInput): DebugAiTrace {
     && input.selection.selectedProvider !== 'template';
 
   // Raw responses mapped to slot roles
-  const rawFallbackResponse = input.editorialGateway.groq.rawText;
-  const rawPrimaryResponse = input.editorialGateway.gemini.rawText;
-  const rawPrimaryPayload = input.editorialGateway.gemini.rawPayload;
+  const rawFallbackResponse = fallbackGateway.rawText;
+  const rawPrimaryResponse = primaryGateway.rawText;
+  const rawPrimaryPayload = 'rawPayload' in primaryGateway
+    ? primaryGateway.rawPayload
+    : undefined;
 
   return {
     // Slot role based fields (new)
@@ -200,11 +208,11 @@ export function buildDebugAiTrace(input: BuildDebugTraceInput): DebugAiTrace {
     fallbackDiagnostics,
 
     // Legacy field names (for backward compatibility)
-    rawGroqResponse: rawFallbackResponse,
-    rawGeminiResponse: rawPrimaryResponse,
-    rawGeminiPayload: rawPrimaryPayload,
-    geminiDiagnostics: primaryDiagnostics,
-    groqDiagnostics: fallbackDiagnostics,
+    rawGroqResponse: input.editorialGateway.groq.rawText,
+    rawGeminiResponse: input.editorialGateway.gemini.rawText,
+    rawGeminiPayload: input.editorialGateway.gemini.rawPayload,
+    geminiDiagnostics: input.editorialGateway.gemini.diagnostics,
+    groqDiagnostics: input.editorialGateway.groq.diagnostics,
 
     apiCallStatuses: apiCallStatuses.length > 0 ? apiCallStatuses : undefined,
     normalizedAiText: traceCandidate?.normalizedAiText || '',


### PR DESCRIPTION
## Summary

Fixes #193.

- map slot-based debug trace fields from `selection.primaryProvider` so primary/fallback responses and diagnostics no longer invert when Groq is preferred
- trim `debugModeSource`, remove dead composition trace wiring, and stop `buildPrompt()` from mutating debug metadata before hydration
- add targeted tests for debug trace mapping and debug-context preparation, and update prompt coverage for the moved metadata responsibility

## Verification

- [x] `npm run typecheck`
- [x] `npm test`
- [x] No README changes required: this only corrects internal debug tracing/metadata flow and does not change user-facing setup or runtime configuration