### PR TITLE
Fix issue #194: Schema tightening & vendor-name to slot-role migration

### DIFF
--- a/src/adapters/n8n/format-messages.adapter.ts
+++ b/src/adapters/n8n/format-messages.adapter.ts
@@ -30,11 +30,7 @@ import type { FinalRuntimePayload } from './contracts/final-runtime-payload.js';
 import { firstInputJson } from './input.js';
 import type { N8nRuntime } from './types.js';
 
-function stringList(value: unknown): string[] | undefined {
-  return Array.isArray(value)
-    ? value.filter((entry): entry is string => typeof entry === 'string')
-    : undefined;
-}
+
 
 export function run({ $input }: N8nRuntime) {
   // Read raw input from n8n

--- a/src/app/run-photo-brief/contracts.ts
+++ b/src/app/run-photo-brief/contracts.ts
@@ -1,7 +1,7 @@
 import type { BriefJson, ScoredForecastContext } from '../../contracts/index.js';
 export type { ScoredForecastContext } from '../../contracts/index.js';
 
-export type EditorialProvider = 'groq' | 'gemini';
+export type EditorialProvider = 'primary' | 'fallback';
 
 export interface ForecastLocation {
   name: string;
@@ -51,9 +51,10 @@ export interface EditorialDecision {
   weekInsight: string;
   spurOfTheMoment?: SpurSuggestion | null;
   geminiInspire?: string;
-  rawGroqResponse?: string;
-  rawGeminiResponse?: string;
-  rawGeminiPayload?: string;
+  // Renamed to slot role naming
+  rawFallbackResponse?: string;
+  rawPrimaryResponse?: string;
+  rawPrimaryPayload?: string;
 }
 
 export interface RenderedOutputs {

--- a/src/domain/editorial/prompt/sections/prompt-blocks.ts
+++ b/src/domain/editorial/prompt/sections/prompt-blocks.ts
@@ -17,13 +17,46 @@ export interface StructuredPromptParts {
 
 export const EDITORIAL_RESPONSE_SCHEMA_NAME = 'photo_brief_editorial_response';
 
-export function buildEditorialResponseSchema(): Record<string, unknown> {
+export function buildLocalWindowResponseSchema(): Record<string, unknown> {
   return {
     type: 'object',
     properties: {
       editorial: { type: 'string' },
       composition: {
         type: 'array',
+        minItems: 2,
+        maxItems: 2,
+        items: { type: 'string' },
+      },
+      weekStandout: { type: 'string' },
+      spurOfTheMoment: {
+        type: 'object',
+        properties: {
+          locationName: { type: 'string' },
+          hookLine: { type: 'string' },
+          confidence: {
+            type: 'number',
+            minimum: 0,
+            maximum: 1,
+          },
+        },
+        required: ['locationName', 'hookLine', 'confidence'],
+        additionalProperties: false,
+      },
+    },
+    required: ['editorial', 'composition', 'weekStandout', 'spurOfTheMoment'],
+    additionalProperties: false,
+  };
+}
+
+export function buildDontBotherResponseSchema(): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      editorial: { type: 'string' },
+      composition: {
+        type: 'array',
+        maxItems: 0,
         items: { type: 'string' },
       },
       weekStandout: { type: 'string' },

--- a/src/lib/debug-context.ts
+++ b/src/lib/debug-context.ts
@@ -124,6 +124,13 @@ export interface DebugPrimaryDiagnostics {
   retryAfter?: number | null;
 }
 
+export interface DebugFallbackDiagnostics {
+  statusCode: number | null;
+  responseByteLength: number | null;
+  /** Rate limit retry-after header value in seconds, if applicable */
+  retryAfter?: number | null;
+}
+
 /**
  * Diagnostics for the fallback AI provider.
  * Previously named DebugGroqDiagnostics, renamed to reflect slot role.
@@ -138,12 +145,8 @@ export interface DebugFallbackDiagnostics {
 /**
  * @deprecated Use DebugPrimaryDiagnostics instead. Kept for backward compatibility.
  */
-export type DebugGeminiDiagnostics = DebugPrimaryDiagnostics;
+// Deprecated aliases removed, consumers updated to slot role naming
 
-/**
- * @deprecated Use DebugFallbackDiagnostics instead. Kept for backward compatibility.
- */
-export type DebugGroqDiagnostics = DebugFallbackDiagnostics;
 
 /**
  * Provider slot type - represents the role of the provider in the editorial pipeline.


### PR DESCRIPTION
This PR tightens the editorial response schema by splitting it into local-window and dont-bother variants with item count constraints. It also completes the migration from vendor-name to slot-role naming across contracts and debug contexts, removing deprecated aliases. Additionally, the unused stringList helper in the n8n adapter has been removed.