### PR TITLE
fix(#205): update assemble test for Merge: Prompt + Gemini FB connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.DS_Store
 
 # Generated artifacts - built in CI
 generated/workflow/photography-weather-brief.json

--- a/workflow/build/README.md
+++ b/workflow/build/README.md
@@ -27,6 +27,7 @@ The workflow skeleton now contains a conditional editorial branch:
 - `HTTP: Groq` runs first in full-response mode
 - `Code: Inspect Groq Primary` decides whether fallback is required
 - `HTTP: Gemini Fallback` only runs when the primary response is clearly unusable
+- `Merge: Prompt + Gemini FB` combines the prompt context with the extracted Gemini fallback response before routing to `Merge: Editorial Route`
 - app-layer template fallback remains the final safety net after the workflow edge
 
 The inspire chain is gated behind a feature flag:

--- a/workflow/build/assemble.test.ts
+++ b/workflow/build/assemble.test.ts
@@ -926,6 +926,7 @@ describe('workflow assembly', () => {
     const ifConnections = data.connections['If: Need Gemini Fallback']?.main ?? [];
     expect(ifConnections[0]).toEqual([
       expect.objectContaining({ node: 'HTTP: Gemini Fallback', index: 0 }),
+      expect.objectContaining({ node: 'Merge: Prompt + Gemini FB', index: 0 }),
     ]);
     expect(ifConnections[1]).toEqual([
       expect.objectContaining({ node: 'Merge: Editorial Route', index: 0 }),


### PR DESCRIPTION
## Summary

Fixes #205

PR #204 (commit `8a48cf1`) correctly wired the true branch of `If: Need Gemini Fallback` to route to both `HTTP: Gemini Fallback` **and** `Merge: Prompt + Gemini FB` in the skeleton. The merge node needs both inputs:

- **index 0**: prompt context forwarded from the If node
- **index 1**: extracted Gemini response from `Code: Extract Gemini Fallback`

However the test assertion in `assemble.test.ts` was not updated, causing CI to fail.

## Changes

- **`workflow/build/assemble.test.ts`**: Updated the `ifConnections[0]` assertion to expect both `HTTP: Gemini Fallback` and `Merge: Prompt + Gemini FB` on the true branch.
- **`workflow/build/README.md`**: Documented the `Merge: Prompt + Gemini FB` node in the editorial branch description.
- **`.gitignore`**: Added `.DS_Store` to prevent macOS metadata files from being committed.

## Verification

All 571 tests pass locally (`npx vitest run`).