### PR TITLE
fix: Use latitude and longitude query parameters for SunsetHue API

### DIFF
--- a/generated/workflow/photography-weather-brief.json
+++ b/generated/workflow/photography-weather-brief.json
@@ -614,7 +614,7 @@
     },
     {
       "parameters": {
-        "url": "https://api.sunsethue.com/forecast?lat=__PHOTO_WEATHER_LAT__&lon=__PHOTO_WEATHER_LON__",
+        "url": "https://api.sunsethue.com/forecast?latitude=__PHOTO_WEATHER_LAT__&longitude=__PHOTO_WEATHER_LON__",
         "sendHeaders": true,
         "specifyHeaders": "keypair",
         "headerParameters": {

--- a/workflow/source/skeleton.json
+++ b/workflow/source/skeleton.json
@@ -614,7 +614,7 @@
     },
     {
       "parameters": {
-        "url": "https://api.sunsethue.com/forecast?lat=__PHOTO_WEATHER_LAT__&lon=__PHOTO_WEATHER_LON__",
+        "url": "https://api.sunsethue.com/forecast?latitude=__PHOTO_WEATHER_LAT__&longitude=__PHOTO_WEATHER_LON__",
         "sendHeaders": true,
         "specifyHeaders": "keypair",
         "headerParameters": {


### PR DESCRIPTION
Fixes #215

The SunsetHue API uses `latitude` and `longitude` as query parameters instead of `lat` and `lon`. This PR updates the `HTTP: SunsetHue` node to correctly pass these coordinates, resolving the issue where the API returned `null`.