### PR TITLE
fix(#217): remove UKMO-unsupported fields from Weather node URL

### DIFF
--- a/generated/workflow/photography-weather-brief.json
+++ b/generated/workflow/photography-weather-brief.json
@@ -54,7 +54,7 @@
     },
     {
       "parameters": {
-        "url": "https://api.open-meteo.com/v1/forecast?latitude=__PHOTO_WEATHER_LAT__&longitude=__PHOTO_WEATHER_LON__&models=ukmo_seamless&hourly=cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,visibility,temperature_2m,relativehumidity_2m,dewpoint_2m,precipitation,windspeed_10m,windgusts_10m,winddirection_10m,cape,vapour_pressure_deficit,total_column_integrated_water_vapour,boundary_layer_height&daily=sunrise,sunset&timezone=__PHOTO_WEATHER_TIMEZONE__&forecast_days=5",
+        "url": "https://api.open-meteo.com/v1/forecast?latitude=__PHOTO_WEATHER_LAT__&longitude=__PHOTO_WEATHER_LON__&models=ukmo_seamless&hourly=cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,visibility,temperature_2m,relativehumidity_2m,dewpoint_2m,precipitation,windspeed_10m,windgusts_10m,winddirection_10m,cape,vapour_pressure_deficit&daily=sunrise,sunset&timezone=__PHOTO_WEATHER_TIMEZONE__&forecast_days=5",
         "options": {}
       },
       "id": "a1b2c3d4-0003-0003-0003-000000000003",

--- a/src/domain/scoring/README.md
+++ b/src/domain/scoring/README.md
@@ -32,6 +32,7 @@ This folder owns weather feature derivation, day scoring, and session recommenda
 
 - `summarize-day.ts` coalesces `null` AirQualityData into static fallbacks (AOD: 0.2, AQI: 25, Dust: 0, UV: 0) and issues console warnings so that downstream feature math survives the shorter Open-Meteo Air Quality forecast horizon.
 - `summarize-day.ts` resolves `precipitation_probability` from the dedicated `PrecipProbData` input (fetched without a model pin so the API's best-match model provides real values). The main weather response does not carry this field.
+- `summarize-day.ts` falls back to 20 for `total_column_integrated_water_vapour` and `null` for `boundary_layer_height` when absent. The UKMO model does not support these fields, so they are not requested in the Weather node URL.
 - `summarize-day.ts` guards `crepRayPeak` against empty `hours` arrays (`Math.max(0, ...)` floor).
 - `features/derive-hour-features.ts` guards `sweetSpotScore` against division-by-zero when `idealMin === hardMin` or `idealMax === hardMax`.
 

--- a/workflow/build/README.md
+++ b/workflow/build/README.md
@@ -31,6 +31,16 @@ The skeleton uses two separate Open-Meteo forecast calls with different model st
 
 If a new hourly field is needed, check whether the chosen model supports it before adding it to a URL. Fields unsupported by a model return `null` arrays.
 
+### UKMO-incompatible fields
+
+The following fields are **not** requested in the `HTTP: Weather` node because `ukmo_seamless` returns `null` for them:
+
+| Field | Scoring fallback | Impact |
+|---|---|---|
+| `precipitation_probability` | Served by `HTTP: Precip Prob` (no model pin) | Real values via best-match model |
+| `total_column_integrated_water_vapour` | Falls back to 20 (neutral — no clarity bonus or penalty) | Scoring degraded; real values would improve clarity assessment |
+| `boundary_layer_height` | Falls back to `null` | Informational only; no direct scoring impact |
+
 The workflow skeleton now contains a conditional editorial branch:
 
 - `HTTP: Groq` runs first in full-response mode

--- a/workflow/build/assemble.test.ts
+++ b/workflow/build/assemble.test.ts
@@ -105,7 +105,9 @@ describe('workflow assembly', () => {
       expect.objectContaining({ node: 'HTTP: Air Quality', index: 0 }),
       expect.objectContaining({ node: 'Code: Wrap Weather', index: 0 }),
     ]));
-    expect(weatherNode?.parameters?.url).toContain('boundary_layer_height');
+    // UKMO does not support these fields — they must NOT appear in the Weather URL
+    expect(weatherNode?.parameters?.url).not.toContain('total_column_integrated_water_vapour');
+    expect(weatherNode?.parameters?.url).not.toContain('boundary_layer_height');
 
     const ensembleConnection = data.connections['HTTP: Ensemble']?.main?.[0]?.[0];
     expect(ensembleConnection?.node).toBe('Code: Wrap Ensemble');
@@ -174,10 +176,14 @@ describe('workflow assembly', () => {
     const weatherNode = skeleton.nodes.find((n: { name: string }) => n.name === 'HTTP: Weather');
     expect(weatherNode).toBeTruthy();
     const weatherUrl: string = weatherNode.parameters.url;
-    // Main weather call should use ukmo_seamless but NOT request precipitation_probability
-    // (precipitation_probability is handled by the dedicated Precip Prob node)
+    // Main weather call should use ukmo_seamless but NOT request fields UKMO can't serve:
+    // - precipitation_probability (handled by dedicated Precip Prob node)
+    // - total_column_integrated_water_vapour (UKMO returns null; scoring falls back to 20)
+    // - boundary_layer_height (UKMO returns null; scoring falls back to null)
     expect(weatherUrl).toContain('models=ukmo_seamless');
     expect(weatherUrl).not.toContain('precipitation_probability');
+    expect(weatherUrl).not.toContain('total_column_integrated_water_vapour');
+    expect(weatherUrl).not.toContain('boundary_layer_height');
     expect(weatherUrl).toContain('precipitation');
   });
 

--- a/workflow/source/skeleton.json
+++ b/workflow/source/skeleton.json
@@ -54,7 +54,7 @@
     },
     {
       "parameters": {
-        "url": "https://api.open-meteo.com/v1/forecast?latitude=__PHOTO_WEATHER_LAT__&longitude=__PHOTO_WEATHER_LON__&models=ukmo_seamless&hourly=cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,visibility,temperature_2m,relativehumidity_2m,dewpoint_2m,precipitation,windspeed_10m,windgusts_10m,winddirection_10m,cape,vapour_pressure_deficit,total_column_integrated_water_vapour,boundary_layer_height&daily=sunrise,sunset&timezone=__PHOTO_WEATHER_TIMEZONE__&forecast_days=5",
+        "url": "https://api.open-meteo.com/v1/forecast?latitude=__PHOTO_WEATHER_LAT__&longitude=__PHOTO_WEATHER_LON__&models=ukmo_seamless&hourly=cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,visibility,temperature_2m,relativehumidity_2m,dewpoint_2m,precipitation,windspeed_10m,windgusts_10m,winddirection_10m,cape,vapour_pressure_deficit&daily=sunrise,sunset&timezone=__PHOTO_WEATHER_TIMEZONE__&forecast_days=5",
         "options": {}
       },
       "id": "a1b2c3d4-0003-0003-0003-000000000003",


### PR DESCRIPTION
Fixes #217

## Summary

- **`skeleton.json` – Weather node**: Remove `total_column_integrated_water_vapour` and `boundary_layer_height` from the hourly field list — UKMO returns `null` arrays with `"undefined"` units for both
- **`assemble.test.ts`**: Update assertions to verify the Weather URL does not contain UKMO-incompatible fields (extends the model/field separation test from PR #214)
- **`workflow/build/README.md`**: Add UKMO-incompatible fields table documenting which fields cannot be served by `ukmo_seamless` and their scoring fallbacks
- **`src/domain/scoring/README.md`**: Document the tpw/blh defensive fallback defaults

## Before/after

```diff
-# Weather — requesting fields UKMO can't serve
-&hourly=...,cape,vapour_pressure_deficit,total_column_integrated_water_vapour,boundary_layer_height&...
+# Weather — only fields UKMO actually supports
+&hourly=...,cape,vapour_pressure_deficit&...
```

## Scoring impact

The scoring code already has sensible fallbacks for missing data:
- `total_column_integrated_water_vapour` → 20 (neutral — no clarity bonus at <15 or penalty at >30)
- `boundary_layer_height` → `null` (informational metadata only, no scoring effect)

## Test plan

- [x] All 572 tests pass (`npx vitest run`)
- [x] `npm run typecheck` passes
- [x] `npm run verify:generated` confirms generated workflow is up to date
- [x] Assemble test validates Weather URL excludes UKMO-incompatible fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)