### PR TITLE
feat(#226): add editorial phrasebook and narrative frame rotation

### DIFF
--- a/src/domain/editorial/README.md
+++ b/src/domain/editorial/README.md
@@ -20,6 +20,10 @@ This folder owns prompt assembly and editorial resolution for the photography br
   Provider-neutral response parsing. Use `parseEditorialResponse()`.
 - [`resolution/week-standout.ts`](./resolution/week-standout.ts)
   Canonical deterministic week-standout resolver. Provider `weekStandout` text is debug/hint input only; final week-standout wording is derived from forecast data.
+- [`phrasebook.ts`](./phrasebook.ts)
+  Controlled threshold-to-word mappings (wind, cloud, visibility, score, confidence). Injected into the prompt context so the LLM sees pre-mapped descriptors alongside raw numbers, reducing arbitrary variation. See #226.
+- [`prompt/sections/narrative-frames.ts`](./prompt/sections/narrative-frames.ts)
+  Deterministic narrative frame selection. Picks one of four structural angles (Plan A / Plan B, Risk-first, Opportunity-first, Timing-critical) based on the day's dominant signal (uncertainty, narrow window, rare condition, viable alternatives). The frame instruction is included in the system prompt. See #226.
 - [`../../contracts/editorial.ts`](../../contracts/editorial.ts)
   Stable re-export surface for external callers.
 
@@ -27,7 +31,9 @@ This folder owns prompt assembly and editorial resolution for the photography br
 
 1. Prompt construction happens in [`prompt/build-prompt.ts`](./prompt/build-prompt.ts).
 2. Shared prompt blocks and the structured response schema live in [`prompt/sections/prompt-blocks.ts`](./prompt/sections/prompt-blocks.ts) and [`prompt/sections/week-standout.ts`](./prompt/sections/week-standout.ts).
-3. Provider JSON/text parsing happens in [`resolution/parse.ts`](./resolution/parse.ts) via `parseEditorialResponse()` — a provider-neutral parser that handles responses from any AI provider (Groq, Gemini, etc.) without tying the code to specific provider naming.
+3. Narrative frame selection happens in [`prompt/sections/narrative-frames.ts`](./prompt/sections/narrative-frames.ts) — a deterministic pick based on forecast signals (uncertainty, window duration, rare conditions, alternatives).
+4. Controlled phrasebook descriptors are generated in [`phrasebook.ts`](./phrasebook.ts) and injected into the prompt context alongside raw numbers.
+5. Provider JSON/text parsing happens in [`resolution/parse.ts`](./resolution/parse.ts) via `parseEditorialResponse()` — a provider-neutral parser that handles responses from any AI provider (Groq, Gemini, etc.) without tying the code to specific provider naming.
 4. The runtime/app edge uses that parser to build an `EditorialGatewayPayload` with normalized text, raw text, parse outcome, diagnostics, and API status metadata.
 5. Factual/editorial checks live in [`resolution/validation.ts`](./resolution/validation.ts).
 6. Composition filtering lives in [`resolution/composition.ts`](./resolution/composition.ts).

--- a/src/domain/editorial/phrasebook.ts
+++ b/src/domain/editorial/phrasebook.ts
@@ -1,0 +1,74 @@
+/**
+ * Controlled phrasebook — threshold-to-word mappings for consistent
+ * numeric-to-language translation in editorial prompts.
+ *
+ * These descriptors are injected into the prompt context so the LLM
+ * sees pre-mapped words alongside raw numbers, reducing arbitrary
+ * variation in how it describes conditions.
+ *
+ * @see https://github.com/garyneville/aperture/issues/226
+ */
+
+// ── Wind ────────────────────────────────────────────────────────
+export function windDescriptor(kph: number): string {
+  if (kph < 5) return 'calm';
+  if (kph < 10) return 'light winds';
+  if (kph < 25) return 'breezy';
+  if (kph < 40) return 'strong winds';
+  return 'gale risk';
+}
+
+// ── Cloud cover (%) ─────────────────────────────────────────────
+export function cloudDescriptor(pct: number): string {
+  if (pct < 10) return 'clear';
+  if (pct < 30) return 'mostly clear';
+  if (pct < 60) return 'partly cloudy';
+  if (pct < 85) return 'mostly cloudy';
+  return 'overcast';
+}
+
+// ── Visibility (km) ─────────────────────────────────────────────
+export function visibilityDescriptor(km: number): string {
+  if (km >= 30) return 'exceptional visibility';
+  if (km >= 15) return 'good visibility';
+  if (km >= 8) return 'moderate visibility';
+  if (km >= 3) return 'poor visibility';
+  return 'very poor visibility';
+}
+
+// ── Overall score quality ───────────────────────────────────────
+export function scoreDescriptor(score: number): string {
+  if (score < 25) return 'poor';
+  if (score < 40) return 'modest';
+  if (score < 55) return 'decent';
+  if (score < 70) return 'good';
+  if (score < 85) return 'strong';
+  return 'exceptional';
+}
+
+// ── Confidence ──────────────────────────────────────────────────
+export function confidenceDescriptor(confidence: string): string {
+  if (confidence === 'high') return 'high confidence';
+  if (confidence === 'medium') return 'fair confidence';
+  if (confidence === 'low') return 'low confidence';
+  return 'unknown confidence';
+}
+
+// ── Aggregate context line for prompt injection ─────────────────
+export interface PhrasebookContext {
+  windKph: number;
+  cloudPct: number;
+  visKm: number;
+  score: number;
+  confidence: string;
+}
+
+export function buildPhrasebookLine(ctx: PhrasebookContext): string {
+  return [
+    `Conditions summary: ${scoreDescriptor(ctx.score)} (${ctx.score}/100)`,
+    `${windDescriptor(ctx.windKph)} (${ctx.windKph} km/h)`,
+    `${cloudDescriptor(ctx.cloudPct)} (${ctx.cloudPct}%)`,
+    `${visibilityDescriptor(ctx.visKm)} (${Math.round(ctx.visKm)} km)`,
+    `${confidenceDescriptor(ctx.confidence)}`,
+  ].join(', ');
+}

--- a/src/domain/editorial/prompt/build-prompt.ts
+++ b/src/domain/editorial/prompt/build-prompt.ts
@@ -34,6 +34,8 @@ import {
   buildDontBotherResponseSchema,
   EDITORIAL_RESPONSE_SCHEMA_NAME,
 } from './sections/prompt-blocks.js';
+import { selectNarrativeFrame } from './sections/narrative-frames.js';
+import { buildPhrasebookLine } from '../phrasebook.js';
 
 export interface KpEntry {
   time: string;
@@ -181,6 +183,26 @@ export function buildPrompt(input: BuildPromptInput): BuildPromptOutput {
       return Number.isFinite(h) && Number.isFinite(m) ? h * 60 + m : 0;
     })();
 
+    const bestWin = windows[0];
+    const narrativeFrame = selectNarrativeFrame({
+      bestWindow: bestWin,
+      todayDay,
+      altLocations,
+      auroraVisibleLocally,
+      peakKpTonight,
+    });
+
+    const bestHour = bestWin?.hours?.find(h => h.score === bestWin.peak) || bestWin?.hours?.[0];
+    const phrasebookLine = bestHour
+      ? buildPhrasebookLine({
+          windKph: bestHour.wind,
+          cloudPct: bestHour.ct,
+          visKm: bestHour.visK,
+          score: bestWin.peak,
+          confidence: todayDay?.confidence ?? 'unknown',
+        })
+      : '';
+
     prompt = buildLocalWindowPrompt({
       homeLocationName,
       windows,
@@ -204,6 +226,8 @@ export function buildPrompt(input: BuildPromptInput): BuildPromptOutput {
       peakKpTonight,
       currentMonth,
       sessionRecommendation,
+      narrativeFrame,
+      phrasebookLine,
     });
     ({ systemPrompt, userPrompt } = buildStructuredLocalWindowPrompt({
       homeLocationName,
@@ -228,6 +252,8 @@ export function buildPrompt(input: BuildPromptInput): BuildPromptOutput {
       peakKpTonight,
       currentMonth,
       sessionRecommendation,
+      narrativeFrame,
+      phrasebookLine,
     }));
   }
 

--- a/src/domain/editorial/prompt/sections/local-window-prompt.ts
+++ b/src/domain/editorial/prompt/sections/local-window-prompt.ts
@@ -12,6 +12,7 @@ import {
   buildWeekStandoutInstructions,
   type StructuredPromptParts,
 } from './prompt-blocks.js';
+import type { NarrativeFrame } from './narrative-frames.js';
 
 const SPUR_LOCATION_NAMES = LONG_RANGE_LOCATIONS.map(l => l.name).join(', ');
 
@@ -38,6 +39,8 @@ export interface LocalWindowPromptParams {
   peakKpTonight: number | null;
   currentMonth: number;
   sessionRecommendation?: SessionRecommendationSummary;
+  narrativeFrame?: NarrativeFrame;
+  phrasebookLine?: string;
 }
 
 type LocalWindowPromptSections = {
@@ -190,7 +193,7 @@ The window card already shows the label, time range, score, and headline metrics
 Use only supplied facts. No camera tips, composition advice, hype, or filler. No emojis. Never return a single sentence. Do not call conditions ideal unless score ≥ 70.
 Do not blame cloud unless the supplied peak-hour cloud cover supports it. If the score gap is explained by visibility or AOD, say that instead.
 The editorial must describe ${homeLocationName} conditions only. Do not name or reference any nearby alternative location, score, or comparison. All alternative detail is in the dedicated card below.
-
+${p.narrativeFrame ? `\nNARRATIVE FRAME (${p.narrativeFrame.label}):\n${p.narrativeFrame.instruction}\n` : ''}
 COMPOSITION (2 short bullet items):
 Suggest 2 concrete shot ideas for the best window. Each must name a specific subject or foreground candidate plus a framing cue, direction, or technique suited to these conditions.
 Avoid generic placeholders like "silhouetted landmark foreground" or "wide-field constellation framing" unless the supplied constraints explicitly support them.
@@ -200,7 +203,7 @@ ${buildWeekStandoutInstructions()}
 ${buildSpurInstructions({ homeLocationName, locationList: SPUR_LOCATION_NAMES })}
 
 Date: ${today} | Current time: ${nowTimeStr} | Sunrise: ${sunriseStr} | Sunset: ${sunsetStr} | Moon: ${moonPct}%
-${contextFacts}
+${p.phrasebookLine ? p.phrasebookLine + '\n' : ''}${contextFacts}
 ${metarNote ? 'METAR: ' + metarNote : ''}
 ${editorialInsights ? `\nEditorial insight options:\n${editorialInsights}` : ''}
 
@@ -243,7 +246,7 @@ EDITORIAL RULES
 - Never call conditions ideal unless the supplied score is 70 or higher.
 - Do not blame cloud unless the supplied peak-hour cloud cover supports it.
 - The editorial must describe ${homeLocationName} conditions only. Do not name or compare nearby alternatives in the editorial.
-
+${p.narrativeFrame ? `\nNARRATIVE FRAME (${p.narrativeFrame.label})\n${p.narrativeFrame.instruction}\n` : ''}
 COMPOSITION RULES
 - composition must contain exactly 2 short shot ideas.
 - Each idea must name a specific subject or foreground candidate plus a framing cue, direction, or technique suited to the supplied conditions.
@@ -262,7 +265,7 @@ SPUR OF THE MOMENT RULES
 
   const userPrompt = `Selected primary window: ${bestWin.label} (${windowRange(bestWin)})
 Date: ${today} | Current time: ${nowTimeStr} | Sunrise: ${sunriseStr} | Sunset: ${sunsetStr} | Moon: ${moonPct}%
-${contextFacts}
+${p.phrasebookLine ? p.phrasebookLine + '\n' : ''}${contextFacts}
 ${metarNote ? `METAR: ${metarNote}\n` : ''}${editorialInsights ? `Editorial insight options:\n${editorialInsights}\n\n` : ''}${shotConstraints ? `Shot constraints:\n${shotConstraints}\n\n` : ''}${homeLocationName} shooting windows:
 ${windowsText}${altText}
 

--- a/src/domain/editorial/prompt/sections/narrative-frames.ts
+++ b/src/domain/editorial/prompt/sections/narrative-frames.ts
@@ -1,0 +1,138 @@
+/**
+ * Narrative frame selection — deterministically picks a structural
+ * angle for the editorial based on the day's dominant forecast signal.
+ *
+ * Instead of letting the LLM vary adjectives ("stunning", "spectacular"),
+ * we rotate the *structural frame* so the briefing reads differently
+ * each day even when conditions are similar.
+ *
+ * @see https://github.com/garyneville/aperture/issues/226
+ */
+
+import type { Window, DailySummary } from '../../../windowing/best-windows.js';
+import type { AltLocationResult } from '../build-prompt.js';
+
+export type NarrativeFrameId =
+  | 'plan-a-plan-b'
+  | 'risk-first'
+  | 'opportunity-first'
+  | 'timing-critical';
+
+export interface NarrativeFrame {
+  id: NarrativeFrameId;
+  label: string;
+  instruction: string;
+}
+
+const FRAMES: Record<NarrativeFrameId, Omit<NarrativeFrame, 'id'>> = {
+  'plan-a-plan-b': {
+    label: 'Plan A / Plan B',
+    instruction:
+      'Structure the editorial as a primary plan with a pivot: lead with the strongest window, then hint at an alternative angle or session if conditions shift.',
+  },
+  'risk-first': {
+    label: 'Risk-first',
+    instruction:
+      'Lead with the forecast uncertainty or risk, then explain what makes the reward worthwhile if it plays out. Frame the window as a calculated bet.',
+  },
+  'opportunity-first': {
+    label: 'Opportunity-first',
+    instruction:
+      'Lead with the standout opportunity — a rare condition, post-frontal clarity, aurora signal, or unusually high score. Frame the window as a moment not to miss.',
+  },
+  'timing-critical': {
+    label: 'Timing-critical',
+    instruction:
+      'Emphasise the narrow timing: when the window opens, when it closes, and why punctuality matters. Frame the session around the clock.',
+  },
+};
+
+export interface FrameSelectionInput {
+  bestWindow: Window;
+  todayDay: DailySummary | undefined;
+  altLocations?: AltLocationResult[];
+  auroraVisibleLocally: boolean;
+  peakKpTonight: number | null;
+}
+
+/**
+ * Select the most appropriate narrative frame based on today's data.
+ *
+ * Priority order (first match wins):
+ * 1. Timing-critical — window span ≤ 2 hours OR strong trend
+ * 2. Risk-first — low/medium confidence with high stdDev
+ * 3. Opportunity-first — rare condition (aurora, exceptional score, crepuscular)
+ * 4. Plan A / Plan B — viable alternatives exist
+ * 5. Opportunity-first — default fallback
+ */
+export function selectNarrativeFrame(input: FrameSelectionInput): NarrativeFrame {
+  const { bestWindow, todayDay, altLocations, auroraVisibleLocally } = input;
+
+  // ── Timing-critical: narrow window or strong trend ────────────
+  const windowDurationHours = getWindowDurationHours(bestWindow);
+  if (windowDurationHours !== null && windowDurationHours <= 2) {
+    return withId('timing-critical');
+  }
+  if (hasStrongTrend(bestWindow)) {
+    return withId('timing-critical');
+  }
+
+  // ── Risk-first: uncertain forecast ────────────────────────────
+  if (todayDay && isUncertainForecast(todayDay)) {
+    return withId('risk-first');
+  }
+
+  // ── Opportunity-first: rare / standout condition ──────────────
+  if (auroraVisibleLocally) {
+    return withId('opportunity-first');
+  }
+  if (bestWindow.peak >= 75) {
+    return withId('opportunity-first');
+  }
+  if (todayDay && todayDay.crepRayPeak > 50) {
+    return withId('opportunity-first');
+  }
+
+  // ── Plan A / Plan B: viable alternatives ──────────────────────
+  if (altLocations && altLocations.length > 0 && altLocations[0].bestScore >= 40) {
+    return withId('plan-a-plan-b');
+  }
+
+  // ── Default: opportunity-first ────────────────────────────────
+  return withId('opportunity-first');
+}
+
+function withId(id: NarrativeFrameId): NarrativeFrame {
+  return { id, ...FRAMES[id] };
+}
+
+function getWindowDurationHours(w: Window): number | null {
+  const startMins = clockToMins(w.start);
+  const endMins = clockToMins(w.end);
+  if (startMins === null || endMins === null) return null;
+  const diff = endMins >= startMins
+    ? endMins - startMins
+    : (24 * 60 - startMins) + endMins; // crosses midnight
+  return diff / 60;
+}
+
+function clockToMins(t: string | undefined): number | null {
+  if (!t) return null;
+  const [h, m] = t.split(':').map(Number);
+  return Number.isFinite(h) && Number.isFinite(m) ? h * 60 + m : null;
+}
+
+function hasStrongTrend(w: Window): boolean {
+  if (!w.hours || w.hours.length < 2) return false;
+  const first = w.hours[0].score;
+  const last = w.hours[w.hours.length - 1].score;
+  return Math.abs(last - first) >= 15;
+}
+
+function isUncertainForecast(day: DailySummary): boolean {
+  const conf = day.confidence;
+  const spread = day.confidenceStdDev;
+  if (conf === 'low') return true;
+  if (conf === 'medium' && spread !== null && spread >= 12) return true;
+  return false;
+}


### PR DESCRIPTION
## Summary

Reduces editorial repetition by introducing two new modules that give the LLM structural tools to vary output instead of recycling adjectives.

Closes #226

## Changes

### New: `src/domain/editorial/phrasebook.ts`
Controlled threshold-to-word mappings for consistent numeric-to-language translation:
- **Wind**: calm / light / breezy / strong / gale risk
- **Cloud cover**: clear / mostly clear / partly cloudy / mostly cloudy / overcast
- **Visibility**: exceptional / good / moderate / poor / very poor
- **Score quality**: poor / modest / decent / good / strong / exceptional
- **Confidence**: high / fair / low / unknown

A `buildPhrasebookLine()` function generates a single context line injected into the prompt so the LLM sees pre-mapped words alongside raw numbers.

### New: `src/domain/editorial/prompt/sections/narrative-frames.ts`
Deterministic narrative frame selection based on the day's dominant forecast signal:
- **Timing-critical** — window ≤ 2 hours or strong improving/deteriorating trend (≥ 15 pt swing)
- **Risk-first** — low confidence or medium confidence with high stdDev (≥ 12)
- **Opportunity-first** — aurora visible, exceptional score (≥ 75), strong crepuscular potential (> 50)
- **Plan A / Plan B** — viable alternatives exist (score ≥ 40)
- Default: Opportunity-first

The frame label and instruction are included in the system prompt (both legacy and structured paths).

### Modified: `src/domain/editorial/prompt/build-prompt.ts`
- Imports and invokes `selectNarrativeFrame()` and `buildPhrasebookLine()`
- Passes both through to local-window prompt builders

### Modified: `src/domain/editorial/prompt/sections/local-window-prompt.ts`
- Accepts optional `narrativeFrame` and `phrasebookLine` in params
- Injects the narrative frame instruction block into both system prompt and legacy prompt
- Injects the phrasebook context line into the user prompt facts section

### Modified: `src/domain/editorial/README.md`
- Documents both new modules in the public entrypoints and flow sections

## Testing
- All 31 editorial tests pass
- All 486 unit tests pass (6 pre-existing failures from missing optional deps unrelated to this change)