### PR TITLE
feat(#224): add physics-based crepuscular ray derivation

### DIFF
--- a/src/domain/scoring/README.md
+++ b/src/domain/scoring/README.md
@@ -43,6 +43,7 @@ This folder owns weather feature derivation, day scoring, and session recommenda
 - `sessions/evaluators/wildlife.ts` uses the physics-based `diffuseToDirectRatio` for soft-light scoring when radiation data is available, falling back to the cloud-cover heuristic when it is not.
 - `features/derive-hour-features.ts` derives `diffuseToDirectRatio` (diffuse / (direct + 1)) and `hasFrost` (soil temp ≤ 0 °C) from raw radiation and soil temperature fields.
 - `features/derive-hour-features.ts` guards `sweetSpotScore` against division-by-zero when `idealMin === hardMin` or `idealMax === hardMax`.
+- `features/derive-hour-features.ts` derives `crepuscularScore` from three multiplicative Van Den Broeke sub-scores: geometry window (solar elevation −4° to 12°), occlusion + gap (broken/layered cloud with gaps), and beam visibility (AOD sweet-spot 0.10–0.30 with moderate humidity). The score is zero outside the geometry window. Previously this was an inline heuristic in `score-hour.ts`; it is now physics-informed and derived alongside other features.
 
 ## What not to edit casually
 

--- a/src/domain/scoring/features/derive-hour-features.test.ts
+++ b/src/domain/scoring/features/derive-hour-features.test.ts
@@ -9,7 +9,6 @@ function makeInput(overrides: Partial<DerivedHourFeatureInput> = {}): DerivedHou
     clarityScore: 68,
     mistScore: 20,
     astroScore: 14,
-    crepuscularScore: 61,
     cloudLowPct: 20,
     cloudMidPct: 30,
     cloudHighPct: 18,
@@ -28,6 +27,7 @@ function makeInput(overrides: Partial<DerivedHourFeatureInput> = {}): DerivedHou
     isGolden: true,
     isBlue: false,
     tags: ['dramatic sky', 'golden hour'],
+    solarAltitudeDeg: 4,
     ...overrides,
   };
 }
@@ -124,5 +124,93 @@ describe('deriveHourFeatures', () => {
 
     // External value should be preserved, not overwritten by the proxy
     expect(features.seeingScore).toBe(85);
+  });
+
+  it('derives a meaningful crepuscular score during golden hour with favourable cloud structure', () => {
+    const good = deriveHourFeatures(makeInput({
+      solarAltitudeDeg: 3,
+      isGolden: true,
+      cloudTotalPct: 55,
+      cloudLowPct: 12,
+      cloudMidPct: 22,
+      cloudHighPct: 30,
+      aerosolOpticalDepth: 0.18,
+      humidityPct: 62,
+      visibilityKm: 20,
+    }));
+
+    expect(good.crepuscularScore).toBeGreaterThan(10);
+  });
+
+  it('returns zero crepuscular score when sun is well above the crepuscular window', () => {
+    const midday = deriveHourFeatures(makeInput({
+      solarAltitudeDeg: 45,
+      isGolden: false,
+      isBlue: false,
+    }));
+
+    expect(midday.crepuscularScore).toBe(0);
+  });
+
+  it('returns zero crepuscular score when sun is well below the crepuscular window', () => {
+    const deepNight = deriveHourFeatures(makeInput({
+      solarAltitudeDeg: -15,
+      isGolden: false,
+      isBlue: false,
+      isNight: true,
+    }));
+
+    expect(deepNight.crepuscularScore).toBe(0);
+  });
+
+  it('scores higher with broken cloud than with overcast or clear sky', () => {
+    const broken = deriveHourFeatures(makeInput({
+      solarAltitudeDeg: 3,
+      cloudTotalPct: 55,
+      cloudLowPct: 10,
+      cloudMidPct: 25,
+      cloudHighPct: 25,
+      aerosolOpticalDepth: 0.18,
+    }));
+    const overcast = deriveHourFeatures(makeInput({
+      solarAltitudeDeg: 3,
+      cloudTotalPct: 95,
+      cloudLowPct: 70,
+      cloudMidPct: 15,
+      cloudHighPct: 10,
+      aerosolOpticalDepth: 0.18,
+    }));
+    const clear = deriveHourFeatures(makeInput({
+      solarAltitudeDeg: 3,
+      cloudTotalPct: 2,
+      cloudLowPct: 1,
+      cloudMidPct: 0,
+      cloudHighPct: 1,
+      aerosolOpticalDepth: 0.18,
+    }));
+
+    expect(broken.crepuscularScore).toBeGreaterThan(overcast.crepuscularScore);
+    expect(broken.crepuscularScore).toBeGreaterThan(clear.crepuscularScore);
+  });
+
+  it('penalises very high or very low AOD for crepuscular beams', () => {
+    const sweetSpot = deriveHourFeatures(makeInput({
+      solarAltitudeDeg: 3,
+      cloudTotalPct: 50,
+      cloudMidPct: 25,
+      cloudHighPct: 20,
+      cloudLowPct: 10,
+      aerosolOpticalDepth: 0.18,
+    }));
+    const tooClean = deriveHourFeatures(makeInput({
+      solarAltitudeDeg: 3,
+      cloudTotalPct: 50,
+      cloudMidPct: 25,
+      cloudHighPct: 20,
+      cloudLowPct: 10,
+      aerosolOpticalDepth: 0.01,
+    }));
+
+    expect(sweetSpot.crepuscularScore).toBeGreaterThan(tooClean.crepuscularScore);
   });
 });

--- a/src/domain/scoring/features/derive-hour-features.ts
+++ b/src/domain/scoring/features/derive-hour-features.ts
@@ -3,6 +3,7 @@ import type { DerivedHourFeatures } from '../../../types/session-score.js';
 
 export type DerivedHourFeatureInput = Omit<
   DerivedHourFeatures,
+  | 'crepuscularScore'
   | 'dewPointSpreadC'
   | 'transparencyScore'
   | 'boundaryLayerTrapScore'
@@ -166,6 +167,86 @@ function estimateSeeingProxy(input: DerivedHourFeatureInput): number | null {
   return clamp(100 - totalRisk);
 }
 
+/**
+ * Physics-informed crepuscular ray likelihood score (0–100).
+ *
+ * Three multiplicative sub-scores based on the Van Den Broeke CRI model:
+ *   1. Geometry window — solar elevation must be in the crepuscular band
+ *      (-4° to 12°) for beams to form between cloud gaps.
+ *   2. Occlusion + gap — broken/layered cloud with gaps; solid overcast
+ *      or clear sky both suppress rays.
+ *   3. Beam visibility — moderate aerosols/haze scatter light into visible
+ *      shafts without erasing contrast.
+ *
+ * Returns 0 outside the geometry window (no crepuscular rays possible).
+ */
+function estimateCrepuscularScore(
+  input: DerivedHourFeatureInput,
+  highCloudTranslucencyScore: number,
+  lowCloudBlockingScore: number,
+): number {
+  const alt = input.solarAltitudeDeg ?? null;
+
+  // ── 1. Geometry window ──────────────────────────────────────────────────
+  // Rays require low-angle sun. Peak at 0–6°, tails to -4° and 12°.
+  let geometry = 0;
+  if (alt === null) {
+    // No solar altitude available — fall back to phase flags
+    geometry = input.isGolden ? 60 : input.isBlue ? 30 : 0;
+  } else if (alt < -4 || alt > 12) {
+    geometry = 0;
+  } else if (alt >= 0 && alt <= 6) {
+    geometry = 100;
+  } else if (alt > 6) {
+    // 6–12°: linear taper
+    geometry = clamp(Math.round(100 - ((alt - 6) / 6) * 100));
+  } else {
+    // -4–0°: twilight rays, linear ramp
+    geometry = clamp(Math.round(((alt + 4) / 4) * 100));
+  }
+
+  if (geometry === 0) return 0;
+
+  // ── 2. Occlusion + gap score ────────────────────────────────────────────
+  // Need broken/layered cloud with gaps. Best: mid-high cloud 25–75%
+  // with low cloud < 50%. Overcast or clear both bad.
+  const cloudGap = sweetSpotScore(input.cloudTotalPct, 30, 70, 5, 95);
+  const layerTexture = sweetSpotScore(
+    input.cloudMidPct + input.cloudHighPct,
+    20, 65, 0, 90,
+  );
+  const lowClearance = clamp(Math.round(Math.max(0, 100 - lowCloudBlockingScore) * 0.8));
+  const translucencyBonus = clamp(Math.round(highCloudTranslucencyScore * 0.3));
+
+  const occlusion = clamp(Math.round(
+    (cloudGap * 0.35)
+    + (layerTexture * 0.30)
+    + (lowClearance * 0.20)
+    + (translucencyBonus * 0.15),
+  ));
+
+  // ── 3. Beam visibility score ────────────────────────────────────────────
+  // Moderate aerosols scatter beams visible; too clean = invisible shafts,
+  // too opaque = extinction. AOD sweet spot: 0.10–0.30.
+  const aodScore = sweetSpotScore(input.aerosolOpticalDepth, 0.10, 0.30, 0.02, 0.55);
+  const humidityScatter = sweetSpotScore(input.humidityPct, 50, 75, 30, 92);
+  const visibilityGate = input.visibilityKm < 5
+    ? clamp(Math.round((input.visibilityKm / 5) * 60))
+    : input.visibilityKm > 30
+      ? 70 // very clear air — less beam scattering
+      : 100;
+
+  const beam = clamp(Math.round(
+    (aodScore * 0.45)
+    + (humidityScatter * 0.30)
+    + (visibilityGate * 0.25),
+  ));
+
+  // ── Composite ───────────────────────────────────────────────────────────
+  // Multiplicative blend: all three factors must be present.
+  return clamp(Math.round((geometry / 100) * (occlusion / 100) * (beam / 100) * 100));
+}
+
 function estimateDiffuseToDirectRatio(input: DerivedHourFeatureInput): number | null {
   if (input.directRadiationWm2 == null || input.diffuseRadiationWm2 == null) return null;
   // Avoid division by zero: add 1 W/m² floor to direct component
@@ -192,6 +273,7 @@ export function deriveHourFeatures(input: DerivedHourFeatureInput): DerivedHourF
   return {
     ...input,
     seeingScore,
+    crepuscularScore: estimateCrepuscularScore(input, highCloudTranslucencyScore, lowCloudBlockingScore),
     dewPointSpreadC: Math.max(0, input.temperatureC - input.dewPointC),
     boundaryLayerTrapScore,
     hazeTrapRisk,

--- a/src/domain/scoring/hourly/score-hour.ts
+++ b/src/domain/scoring/hourly/score-hour.ts
@@ -150,6 +150,8 @@ export function scoreHour(p: ScoreHourParams): ScoreHourResult {
   }
 
   // ── CREPUSCULAR RAYS ──────────────────────────────────────────────────────
+  // Now derived in derive-hour-features.ts via estimateCrepuscularScore().
+  // Kept here only for the ScoredHour legacy field and tag logic.
   let crepuscular = 0;
   if (p.isGolden) {
     const elev = solarElevation(+t, p.lat, p.lon);
@@ -198,7 +200,6 @@ export function scoreHour(p: ScoreHourParams): ScoreHourResult {
     clarityScore: clarity,
     mistScore: mist,
     astroScore: astro,
-    crepuscularScore: crepuscular,
     cloudLowPct: p.cl,
     cloudMidPct: p.cm,
     cloudHighPct: p.ch,

--- a/src/domain/scoring/sessions/index.test.ts
+++ b/src/domain/scoring/sessions/index.test.ts
@@ -17,7 +17,6 @@ function makeHour(overrides: Partial<DerivedHourFeatureInput> = {}): DerivedHour
     clarityScore: 68,
     mistScore: 20,
     astroScore: 14,
-    crepuscularScore: 61,
     cloudLowPct: 20,
     cloudMidPct: 30,
     cloudHighPct: 18,
@@ -1003,7 +1002,7 @@ describe('session scoring foundation', () => {
     expect(summary.primary?.session).toBe('storm');
     expect(summary.primary?.hourLabel).toBe('19:00');
     expect(summary.hoursAnalyzed).toBe(2);
-    expect(summary.bySession.map(entry => entry.session)).toEqual(['storm', 'long-exposure', 'golden-hour', 'mist', 'urban', 'wildlife', 'astro']);
+    expect(summary.bySession.map(entry => entry.session)).toEqual(['storm', 'long-exposure', 'mist', 'golden-hour', 'urban', 'wildlife', 'astro']);
     expect(summary.runnerUps[0]?.session).toBe('long-exposure');
   });
 


### PR DESCRIPTION
## Summary

Replaces the inline crepuscular heuristic in `score-hour.ts` with a physics-informed `estimateCrepuscularScore()` function in `derive-hour-features.ts`, consistent with how all other derived features (transparency, seeing, boundary-layer trap, etc.) are computed.

## What changed

### `src/domain/scoring/features/derive-hour-features.ts`
- Added `estimateCrepuscularScore()` implementing three multiplicative Van Den Broeke sub-scores:
  1. **Geometry window** — solar elevation sweet-spot scoring for the crepuscular band (-4° to 12°), peak at 0–6°
  2. **Occlusion + gap** — broken/layered cloud with gaps using cloud-layer percentages, high-cloud translucency, and low-cloud blocking
  3. **Beam visibility** — AOD sweet-spot (0.10–0.30) combined with moderate humidity for beam scattering, gated by visibility
- Added `crepuscularScore` to the `DerivedHourFeatureInput` Omit list (now derived, not passed through)
- Called in `deriveHourFeatures()` alongside other derived features

### `src/domain/scoring/hourly/score-hour.ts`
- Removed `crepuscularScore` from `featureInput` (no longer passed to derivation layer)
- Retained inline crepuscular calculation for `ScoredHour` legacy field and tag logic only

### `src/domain/scoring/features/derive-hour-features.test.ts`
- Added 4 new tests: geometry window boundaries, cloud-gap scenarios, AOD sweet-spot, midday/night zero-score

### `src/domain/scoring/sessions/index.test.ts`
- Updated `makeHour` default to reflect new derived crepuscular score
- Adjusted one session ranking assertion (golden-hour vs mist ordering) reflecting the more accurate physics-based score

### `src/domain/scoring/README.md`
- Documented the new crepuscular ray derivation in defensive guards section

## Test results
All 84 related tests pass (11 derive-hour-features + 55 sessions + 9 best-windows + 9 satellite-clearing).

Closes #224