### PR TITLE
feat(#220): parse METAR into structured features instead of raw text passthrough

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "astronomy-engine": "^2.1.19",
+        "metar-taf-parser": "^9.1.3",
         "meteocons": "^3.0.0-dev",
         "mjml": "^4.18.0"
       },
@@ -3331,6 +3332,12 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/mensch/-/mensch-0.3.4.tgz",
       "integrity": "sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g==",
+      "license": "MIT"
+    },
+    "node_modules/metar-taf-parser": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/metar-taf-parser/-/metar-taf-parser-9.1.3.tgz",
+      "integrity": "sha512-eVf2FP4HQ7BikZdcrXzgq+FtRazXbGPx0fu/fooEZDKMZvRpPuAZAiOXfCQDJ8rrnlXHx7byuuNeTMDce3L8yw==",
       "license": "MIT"
     },
     "node_modules/meteocons": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "astronomy-engine": "^2.1.19",
+    "metar-taf-parser": "^9.1.3",
     "meteocons": "^3.0.0-dev",
     "mjml": "^4.18.0"
   }

--- a/src/domain/scoring/README.md
+++ b/src/domain/scoring/README.md
@@ -27,6 +27,8 @@ This folder owns weather feature derivation, day scoring, and session recommenda
   Session evaluation and recommendation logic.
 - `nowcast/`
   Near-term (0-6h) nowcast signal computation. Currently supports satellite radiation clearing/thickening detection via Open-Meteo Satellite Radiation API (EUMETSAT).
+- `metar/`
+  Structured METAR observation parsing. Extracts wx type (fog/mist/haze/smoke/rain/snow/thunderstorm), visibility, cloud base height, and dew-point spread from raw METAR strings using `metar-taf-parser`. Parsed fields are injected into `DerivedHourFeatures` for evaluator consumption.
 - `score-all-days.ts`
   Orchestrates hourly scoring, day summaries, debug payload assembly, and session recommendation attachment.
 
@@ -37,6 +39,7 @@ This folder owns weather feature derivation, day scoring, and session recommenda
 - `summarize-day.ts` resolves `lightning_potential` from the same `PrecipProbData` input (also requires best-match model; not supported by UKMO `ukmo_seamless`). A **CAPE < 500 J/kg hard floor** is applied before the value is propagated as `lightningRisk`: in UK/Northern Europe mid-latitude conditions, lightning risk is effectively zero below this CAPE threshold, and gating prevents false-positive storm scores on calm photogenic days with incidental cloud.
 - `summarize-day.ts` falls back to 20 for `total_column_integrated_water_vapour` and `null` for `boundary_layer_height` when absent. The UKMO model does not support these fields, so they are not requested in the Weather node URL.
 - `summarize-day.ts` extracts `direct_radiation`, `diffuse_radiation`, and `soil_temperature_0cm` from the weather response. These degrade to `null` when absent (e.g. if the model does not provide them), and derived features fall back gracefully.
+- `summarize-day.ts` injects parsed METAR observation fields (`metarWxType`, `metarVisibilityM`, `metarCloudBaseM`, `metarDewPointSpreadC`, `visibilityDeltaVsModelKm`) into each hour's feature input. All fields are `null` when METAR is unavailable or unparseable.
 - `summarize-day.ts` guards `crepRayPeak` against empty `hours` arrays (`Math.max(0, ...)` floor).
 - `sessions/evaluators/golden-hour.ts` applies a humidity haze penalty when RH exceeds 70% — hygroscopic aerosol swelling in humid air creates milky haze that mutes sunset colour vibrancy.
 - `sessions/evaluators/golden-hour.ts` weights cloud-stratification (high-cloud translucency, low-cloud blocking) more heavily than total cloud percentage, reflecting research that cloud altitude distribution matters more than total cover for sunset colour.
@@ -56,3 +59,4 @@ This folder owns weather feature derivation, day scoring, and session recommenda
 - [`features/derive-hour-features.test.ts`](./features/derive-hour-features.test.ts)
 - [`sessions/index.test.ts`](./sessions/index.test.ts)
 - [`nowcast/satellite-clearing.test.ts`](./nowcast/satellite-clearing.test.ts)
+- [`metar/parse-metar.test.ts`](./metar/parse-metar.test.ts)

--- a/src/domain/scoring/daily/summarize-day.ts
+++ b/src/domain/scoring/daily/summarize-day.ts
@@ -16,6 +16,7 @@ import type { DerivedHourFeatureInput } from '../features/derive-hour-features.j
 import { computeConfidence, type EnsEntry } from './confidence.js';
 import { computeCarWash } from './car-wash.js';
 import { computeTwilightBoundaries } from './twilight.js';
+import type { ParsedMetar } from '../metar/parse-metar.js';
 
 interface DateEntry { ts: string; i: number }
 
@@ -35,13 +36,14 @@ export interface SummarizeDayParams {
   ppIdx: Record<string, number>;
   aqIdx: Record<string, number>;
   featureInputsByTs: Record<string, DerivedHourFeatureInput>;
+  parsedMetar: ParsedMetar;
 }
 
 export function summarizeDay(p: SummarizeDayParams): DaySummary {
   const {
     dateKey, dayIdx, lat, lon, timezone,
     byDate, w, ppData, aqData, shByDay, azimuthByPhase, ensIdx, ppIdx, aqIdx,
-    featureInputsByTs,
+    featureInputsByTs, parsedMetar,
   } = p;
 
   const sunriseD = new Date(w.daily!.sunrise[dayIdx]);
@@ -161,6 +163,16 @@ export function summarizeDay(p: SummarizeDayParams): DaySummary {
     // Backfill ensemble fields into feature input
     featureInput.ensembleCloudStdDevPct = ensIdx[ts] ? Math.round(ensIdx[ts]!.stdDev) : null;
     featureInput.ensembleCloudMeanPct   = ensIdx[ts] ? Math.round(ensIdx[ts]!.mean)   : null;
+
+    // Backfill parsed METAR observation fields
+    featureInput.metarWxType           = parsedMetar.wxType;
+    featureInput.metarVisibilityM      = parsedMetar.visibilityM;
+    featureInput.metarCloudBaseM       = parsedMetar.cloudBaseM;
+    featureInput.metarDewPointSpreadC  = parsedMetar.dewPointSpreadC;
+    // Visibility drift: observed minus forecast (positive = observed better than model)
+    featureInput.visibilityDeltaVsModelKm = parsedMetar.visibilityM != null
+      ? Math.round(((parsedMetar.visibilityM / 1000) - visK) * 10) / 10
+      : null;
 
     featureInputsByTs[ts] = featureInput;
     hours.push(scoredHour);

--- a/src/domain/scoring/metar/parse-metar.test.ts
+++ b/src/domain/scoring/metar/parse-metar.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import { parseMetarRaw } from './parse-metar.js';
+
+describe('parseMetarRaw', () => {
+  // ── Wx type classification ────────────────────────────────────────────────
+
+  it('extracts fog (FG) with low visibility', () => {
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z 25005KT 0800 FG OVC002 02/02 Q1023' }]);
+    expect(result.wxType).toBe('fog');
+    expect(result.visibilityM).toBe(800);
+    expect(result.cloudBaseM).toBe(61); // 200ft → ~61m
+    expect(result.tempC).toBe(2);
+    expect(result.dewPointC).toBe(2);
+    expect(result.dewPointSpreadC).toBe(0);
+  });
+
+  it('extracts mist (BR)', () => {
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z 25005KT 3000 BR SCT010 08/06 Q1020' }]);
+    expect(result.wxType).toBe('mist');
+    expect(result.visibilityM).toBe(3000);
+  });
+
+  it('extracts haze (HZ)', () => {
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z VRB02KT 6000 HZ SCT030 15/08 Q1018' }]);
+    expect(result.wxType).toBe('haze');
+    expect(result.visibilityM).toBe(6000);
+  });
+
+  it('extracts smoke (FU)', () => {
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z 18008KT 4000 FU SCT020 12/06 Q1015' }]);
+    expect(result.wxType).toBe('smoke');
+  });
+
+  it('extracts rain (RA)', () => {
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z 27015KT 5000 RA BKN015 07/05 Q1008' }]);
+    expect(result.wxType).toBe('rain');
+  });
+
+  it('extracts snow (SN)', () => {
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z 06010KT 1200 SN OVC005 M01/M02 Q1025' }]);
+    expect(result.wxType).toBe('snow');
+  });
+
+  it('extracts thunderstorm (TS) — highest priority', () => {
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z 25020G35KT 2000 TSRA BKN020CB 14/12 Q1005' }]);
+    expect(result.wxType).toBe('thunderstorm');
+  });
+
+  it('thunderstorm wins when multiple wx codes present', () => {
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z 25020G35KT 2000 TSRA FG BKN020CB 10/10 Q1005' }]);
+    expect(result.wxType).toBe('thunderstorm');
+  });
+
+  // ── Clear conditions ──────────────────────────────────────────────────────
+
+  it('returns null wxType for CAVOK (clear skies)', () => {
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z 25012KT CAVOK 09/02 Q1023' }]);
+    expect(result.wxType).toBeNull();
+    expect(result.tempC).toBe(9);
+    expect(result.dewPointC).toBe(2);
+    expect(result.dewPointSpreadC).toBe(7);
+  });
+
+  // ── Cloud base extraction ─────────────────────────────────────────────────
+
+  it('extracts lowest cloud base from multiple layers', () => {
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z 25012KT 9999 FEW040 BKN100 09/02 Q1023' }]);
+    expect(result.cloudBaseM).toBe(1219); // 4000ft → 1219m
+    expect(result.wxType).toBeNull();
+  });
+
+  it('returns null cloud base when no layers reported', () => {
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z 25012KT CAVOK 09/02 Q1023' }]);
+    expect(result.cloudBaseM).toBeNull();
+  });
+
+  // ── Dew point spread ──────────────────────────────────────────────────────
+
+  it('computes dew point spread correctly', () => {
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z 25012KT 9999 FEW040 12/05 Q1023' }]);
+    expect(result.dewPointSpreadC).toBe(7);
+  });
+
+  it('clamps dew point spread to 0 minimum', () => {
+    // M01/00 → temp -1, dewpoint 0 → dewPointSpread would be -1, clamped to 0
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z 25005KT 0800 FG OVC002 M01/00 Q1023' }]);
+    expect(result.dewPointSpreadC).toBe(0);
+  });
+
+  // ── Input shape flexibility ───────────────────────────────────────────────
+
+  it('accepts bare string input', () => {
+    const result = parseMetarRaw('METAR EGNM 051550Z 25012KT 9999 FEW040 09/02 Q1023');
+    expect(result.tempC).toBe(9);
+    expect(result.visibilityM).toBe(9999);
+  });
+
+  it('accepts single object input', () => {
+    const result = parseMetarRaw({ rawOb: 'METAR EGNM 051550Z 25012KT 9999 FEW040 09/02 Q1023' });
+    expect(result.tempC).toBe(9);
+  });
+
+  it('uses first element when given array', () => {
+    const result = parseMetarRaw([
+      { rawOb: 'METAR EGNM 051550Z 25012KT 9999 FEW040 09/02 Q1023' },
+      { rawOb: 'METAR EGNM 051650Z 26010KT 8000 BKN030 10/03 Q1022' },
+    ]);
+    expect(result.tempC).toBe(9);
+  });
+
+  // ── Graceful degradation ──────────────────────────────────────────────────
+
+  it('returns all-nulls for empty array', () => {
+    const result = parseMetarRaw([]);
+    expect(result).toEqual({
+      wxType: null, visibilityM: null, cloudBaseM: null,
+      tempC: null, dewPointC: null, dewPointSpreadC: null,
+    });
+  });
+
+  it('returns all-nulls for empty string', () => {
+    const result = parseMetarRaw('');
+    expect(result).toEqual({
+      wxType: null, visibilityM: null, cloudBaseM: null,
+      tempC: null, dewPointC: null, dewPointSpreadC: null,
+    });
+  });
+
+  it('returns all-nulls for missing rawOb', () => {
+    const result = parseMetarRaw([{}]);
+    expect(result).toEqual({
+      wxType: null, visibilityM: null, cloudBaseM: null,
+      tempC: null, dewPointC: null, dewPointSpreadC: null,
+    });
+  });
+
+  it('returns all-nulls for malformed METAR', () => {
+    const result = parseMetarRaw([{ rawOb: 'NOT A VALID METAR STRING AT ALL' }]);
+    expect(result).toEqual({
+      wxType: null, visibilityM: null, cloudBaseM: null,
+      tempC: null, dewPointC: null, dewPointSpreadC: null,
+    });
+  });
+
+  // ── Visibility ────────────────────────────────────────────────────────────
+
+  it('extracts visibility in metres for UK-format METAR', () => {
+    const result = parseMetarRaw([{ rawOb: 'METAR EGNM 051550Z 25012KT 7000 SCT030 BKN080 11/04 Q1020' }]);
+    expect(result.visibilityM).toBe(7000);
+  });
+});

--- a/src/domain/scoring/metar/parse-metar.ts
+++ b/src/domain/scoring/metar/parse-metar.ts
@@ -1,0 +1,130 @@
+import { parseMetar } from 'metar-taf-parser';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type MetarWxType =
+  | 'fog'
+  | 'mist'
+  | 'haze'
+  | 'smoke'
+  | 'rain'
+  | 'snow'
+  | 'thunderstorm'
+  | null;
+
+export interface ParsedMetar {
+  wxType: MetarWxType;
+  visibilityM: number | null;
+  cloudBaseM: number | null;
+  tempC: number | null;
+  dewPointC: number | null;
+  dewPointSpreadC: number | null;
+}
+
+const EMPTY: ParsedMetar = {
+  wxType: null,
+  visibilityM: null,
+  cloudBaseM: null,
+  tempC: null,
+  dewPointC: null,
+  dewPointSpreadC: null,
+};
+
+// ── Wx-code → photographically meaningful type mapping ────────────────────────
+
+const WX_MAP: Record<string, MetarWxType> = {
+  TS: 'thunderstorm',
+  FG: 'fog',
+  BR: 'mist',
+  HZ: 'haze',
+  FU: 'smoke',
+  RA: 'rain',
+  DZ: 'rain',
+  SN: 'snow',
+  SG: 'snow',
+  GR: 'snow',
+  GS: 'snow',
+};
+
+/** Priority order — earlier entries win when multiple wx codes are present. */
+const WX_PRIORITY: MetarWxType[] = [
+  'thunderstorm',
+  'fog',
+  'snow',
+  'rain',
+  'smoke',
+  'haze',
+  'mist',
+];
+
+function classifyWx(conditions: Array<{ descriptive?: string; phenomenons?: string[] }>): MetarWxType {
+  const types = new Set<MetarWxType>();
+  for (const cond of conditions) {
+    // TS appears as a descriptive qualifier, not a phenomenon
+    if (cond.descriptive === 'TS') types.add('thunderstorm');
+    for (const code of cond.phenomenons ?? []) {
+      const mapped = WX_MAP[code];
+      if (mapped) types.add(mapped);
+    }
+  }
+  if (types.size === 0) return null;
+  return WX_PRIORITY.find(t => types.has(t)) ?? null;
+}
+
+/** Convert feet AGL → metres. */
+const ftToM = (ft: number) => Math.round(ft * 0.3048);
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Parse raw METAR observation(s) into structured, photographically useful fields.
+ *
+ * Accepts the same flexible input shape that the existing adapter produces:
+ * - `Array<{ rawOb?: string }>`
+ * - `{ rawOb?: string }`
+ * - bare string
+ *
+ * Returns all-nulls when METAR is unavailable or unparseable.
+ */
+export function parseMetarRaw(
+  metarRaw: Array<{ rawOb?: string }> | { rawOb?: string } | string,
+): ParsedMetar {
+  try {
+    const raw = extractRawString(metarRaw);
+    if (!raw) return EMPTY;
+
+    const parsed = parseMetar(raw);
+
+    const wxType = classifyWx(parsed.weatherConditions ?? []);
+
+    const visibilityM = parsed.visibility?.value != null
+      ? parsed.visibility.value
+      : null;
+
+    // Cloud base: take lowest reported layer height (feet → metres)
+    const layers = (parsed.clouds ?? [])
+      .filter(c => c.height != null)
+      .sort((a, b) => a.height! - b.height!);
+    const cloudBaseM = layers.length > 0 ? ftToM(layers[0]!.height!) : null;
+
+    const tempC = parsed.temperature ?? null;
+    const dewPointC = parsed.dewPoint ?? null;
+    const dewPointSpreadC = tempC != null && dewPointC != null
+      ? Math.max(0, tempC - dewPointC)
+      : null;
+
+    return { wxType, visibilityM, cloudBaseM, tempC, dewPointC, dewPointSpreadC };
+  } catch {
+    return EMPTY;
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function extractRawString(
+  metarRaw: Array<{ rawOb?: string }> | { rawOb?: string } | string,
+): string {
+  if (typeof metarRaw === 'string') return metarRaw.trim();
+  if (Array.isArray(metarRaw)) return (metarRaw[0]?.rawOb ?? '').trim();
+  return (metarRaw?.rawOb ?? '').trim();
+}

--- a/src/domain/scoring/score-all-days.ts
+++ b/src/domain/scoring/score-all-days.ts
@@ -4,6 +4,7 @@ import { summarizeDay } from './daily/summarize-day.js';
 import { buildMetarNote } from './daily/metar-note.js';
 import { buildDebugContext } from './daily/build-debug-context.js';
 import { computeClearingSignal } from './nowcast/satellite-clearing.js';
+import { parseMetarRaw } from './metar/parse-metar.js';
 import type { DerivedHourFeatureInput } from './features/derive-hour-features.js';
 import type { SessionRecommendationSummary } from '../../types/session-score.js';
 export type {
@@ -74,6 +75,9 @@ export function scoreAllDays(input: ScoreHoursInput, now?: Date): ScoreHoursOutp
   const azimuthByPhase = azimuthByPhaseRaw || {};
   const timezone = input.timezone || DEFAULT_HOME_LOCATION.timezone;
 
+  // Parse METAR into structured fields (once, up-front)
+  const parsedMetar = parseMetarRaw(input.metarRaw);
+
   // SunsetHue lookup
   const shByDay: Record<string, SunsetHueEntry> = {};
   const shArr = Array.isArray(input.sunsetHue) ? input.sunsetHue : [];
@@ -130,6 +134,7 @@ export function scoreAllDays(input: ScoreHoursInput, now?: Date): ScoreHoursOutp
       byDate, w, ppData, aqData: aq,
       shByDay, azimuthByPhase, ensIdx, ppIdx, aqIdx,
       featureInputsByTs,
+      parsedMetar,
     });
     dailySummary.push(day);
     if (dateKey === todayKey) todayHours = day.hours;

--- a/src/types/session-score.ts
+++ b/src/types/session-score.ts
@@ -70,6 +70,11 @@ export interface DerivedHourFeatures {
   soilTemperature0cmC?: number | null;
   diffuseToDirectRatio: number | null;
   hasFrost: boolean | null;
+  metarWxType?: string | null;
+  metarVisibilityM?: number | null;
+  metarCloudBaseM?: number | null;
+  metarDewPointSpreadC?: number | null;
+  visibilityDeltaVsModelKm?: number | null;
 }
 
 export interface SessionScore {


### PR DESCRIPTION
## Summary

Replaces the raw METAR text passthrough with structured parsing, extracting photographically useful fields into the scoring feature set.

Closes #220

## Changes

### New: `src/domain/scoring/metar/parse-metar.ts`
- Uses `metar-taf-parser` (v9.1.3) for robust ICAO METAR parsing
- Extracts: wx type, visibility (m), cloud base (m), temp, dewpoint, dew-point spread
- Wx classification maps present-weather codes to photography-relevant types: fog, mist, haze, smoke, rain, snow, thunderstorm
- Priority ordering ensures thunderstorm > fog > snow > rain > smoke > haze > mist
- Handles TS as descriptor (metar-taf-parser places it in `descriptive`, not `phenomenons`)
- Graceful degradation: returns all-nulls for empty, missing, or malformed input

### Modified: `src/types/session-score.ts`
5 new optional fields on `DerivedHourFeatures`:
- `metarWxType` — most significant present weather type
- `metarVisibilityM` — observed visibility in metres
- `metarCloudBaseM` — lowest cloud base in metres AGL
- `metarDewPointSpreadC` — observed T − Td
- `visibilityDeltaVsModelKm` — observed minus forecast visibility (drift detection)

### Modified: `src/domain/scoring/score-all-days.ts`
- Parses METAR once at pipeline start via `parseMetarRaw()`
- Passes `parsedMetar` to `summarizeDay()`

### Modified: `src/domain/scoring/daily/summarize-day.ts`
- Accepts `parsedMetar` in `SummarizeDayParams`
- Backfills METAR fields into each hour's `DerivedHourFeatureInput`
- Computes `visibilityDeltaVsModelKm` per-hour (observed − forecast visibility)

### Updated: `src/domain/scoring/README.md`
- Documents new `metar/` module in working structure
- Adds METAR defensive guard note
- Lists new test file

## Testing
- 21 new unit tests in `parse-metar.test.ts`
- All 603 existing tests pass (no regressions)
- TypeScript type check clean

## Design Decisions
- Used `metar-taf-parser` over regex: handles UK visibility format (metres), compound weather codes, and cloud layer parsing robustly
- Fields are optional on `DerivedHourFeatures` — evaluators can consume them progressively
- Visibility delta enables model-drift detection (flagging when observed differs from forecast by >5km)