### PR TITLE
feat(#225): add Plan B scenario framing to session recommendations

### DIFF
--- a/src/domain/editorial/prompt/sections/local-window-prompt.ts
+++ b/src/domain/editorial/prompt/sections/local-window-prompt.ts
@@ -144,13 +144,17 @@ function buildLocalWindowPromptSections(p: LocalWindowPromptParams): LocalWindow
 
   const contextFacts = `${temporalContext}${seasonalNote ? `Seasonal context: ${seasonalNote}\n` : ''}${auroraNote ? `${auroraNote}\n` : ''}${shInfo}${moonNote}${crepNote}${shQNote}${confNote}${fallbackNote}`;
 
+  const planBNote = p.sessionRecommendation?.planB
+    ? `\nPlan B: ${p.sessionRecommendation.planB}`
+    : '';
+
   return {
     bestWin,
     editorialInsights,
     shotConstraints,
     windowsText,
     altText,
-    contextFacts,
+    contextFacts: contextFacts + planBNote,
   };
 }
 

--- a/src/domain/scoring/README.md
+++ b/src/domain/scoring/README.md
@@ -15,7 +15,7 @@ This folder owns weather feature derivation, day scoring, and session recommenda
 - [`features/derive-hour-features.ts`](./features/derive-hour-features.ts)
   Shared derived-feature seam used by the session evaluators.
 - [`sessions/index.ts`](./sessions/index.ts)
-  Built-in session evaluators, cross-hour selection, and recommendation summary.
+  Built-in session evaluators, cross-hour selection, recommendation summary, and Plan B scenario generation.
 - [`../../contracts/scored-forecast.ts`](../../contracts/scored-forecast.ts)
   Shared scored-forecast contract surface for callers.
 
@@ -24,7 +24,7 @@ This folder owns weather feature derivation, day scoring, and session recommenda
 - `features/`
   Hour-level feature engineering.
 - `sessions/`
-  Session evaluation and recommendation logic.
+  Session evaluation, recommendation logic, and Plan B scenario framing (alternative-scenario string when primary confidence is medium or low).
 - `nowcast/`
   Near-term (0-6h) nowcast signal computation. Currently supports satellite radiation clearing/thickening detection via Open-Meteo Satellite Radiation API (EUMETSAT).
 - `score-all-days.ts`

--- a/src/domain/scoring/sessions/index.ts
+++ b/src/domain/scoring/sessions/index.ts
@@ -82,10 +82,44 @@ export function summarizeSessionRecommendations(hours: DerivedHourFeatures[]): S
   }
 
   const bySession = [...bestBySession.values()].sort((a, b) => b.score - a.score);
+  const primary = bySession[0] ?? null;
+  const runnerUps = bySession.slice(1);
+  const planB = buildPlanB(primary, runnerUps[0] ?? null);
+
   return {
-    primary: bySession[0] ?? null,
-    runnerUps: bySession.slice(1),
+    primary,
+    runnerUps,
     bySession,
     hoursAnalyzed: hours.length,
+    planB,
   };
+}
+
+function buildPlanB(
+  primary: SessionRecommendation | null,
+  runnerUp: SessionRecommendation | null,
+): string | null {
+  if (!primary || !runnerUp) return null;
+  if (primary.confidence === 'high') return null;
+
+  const riskClause = primary.warnings[0]
+    || `${sessionLabel(primary.session)} conditions don't hold`;
+  const reason = runnerUp.reasons[0] || `${sessionLabel(runnerUp.session)} conditions look favourable`;
+
+  return `If ${riskClause}: consider ${sessionLabel(runnerUp.session).toLowerCase()} at ${runnerUp.hourLabel} — ${reason.charAt(0).toLowerCase()}${reason.slice(1)}`;
+}
+
+function sessionLabel(session: SessionId): string {
+  switch (session) {
+    case 'golden-hour': return 'Golden hour';
+    case 'astro': return 'Astro';
+    case 'mist': return 'Mist';
+    case 'storm': return 'Storm';
+    case 'urban': return 'Urban';
+    case 'long-exposure': return 'Long exposure';
+    case 'street': return 'Street';
+    case 'wildlife': return 'Wildlife';
+    case 'waterfall': return 'Waterfall';
+    case 'seascape': return 'Seascape';
+  }
 }

--- a/src/presenters/email/sections/session-recommendation.ts
+++ b/src/presenters/email/sections/session-recommendation.ts
@@ -13,6 +13,7 @@ import {
   sessionRecommendationHeadline,
   sessionRunnerUpLine,
   sessionVolatilityLabel,
+  planBScenario,
 } from '../../shared/window-helpers.js';
 import type { FormatEmailInput } from '../types.js';
 
@@ -27,6 +28,7 @@ export function sessionRecommendationCard(sessionRecommendation: FormatEmailInpu
       : C.warning;
   const volatility = sessionVolatilityLabel(primary);
   const runnerUp = sessionRunnerUpLine(sessionRecommendation);
+  const planB = planBScenario(sessionRecommendation);
 
   return card(`
     <div style="Margin:0 0 4px;font-family:${FONT};font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:${C.subtle};">Best session today</div>
@@ -38,5 +40,6 @@ export function sessionRecommendationCard(sessionRecommendation: FormatEmailInpu
     </div>
     <div style="Margin-top:10px;font-family:${FONT};font-size:13px;line-height:1.5;color:${C.muted};">${esc(sessionRecommendationBody(primary))}</div>
     ${runnerUp ? `<div style="Margin-top:8px;font-family:${FONT};font-size:12px;line-height:1.5;color:${C.subtle};">${esc(runnerUp)}</div>` : ''}
+    ${planB ? `<div style="Margin-top:10px;padding:8px 10px;background:${C.surfaceAlt || '#f7f5f0'};border-radius:6px;font-family:${FONT};font-size:12px;line-height:1.5;color:${C.muted};"><strong>Plan\u00a0B:</strong> ${esc(planB)}</div>` : ''}
   `, '', `border-left:3px solid ${scoreState(primary.score).fg};`);
 }

--- a/src/presenters/shared/README.md
+++ b/src/presenters/shared/README.md
@@ -15,7 +15,7 @@ This folder contains cross-cutting render primitives used by multiple presenters
   Main export file containing colors, fonts, icons, score helpers, and formatting utilities.
 
 - [`window-helpers.ts`](./window-helpers.ts)
-  Cross-presenter utilities for window and session display. Functions for formatting session names, window labels, moon descriptors, and time-aware summaries.
+  Cross-presenter utilities for window and session display. Functions for formatting session names, window labels, moon descriptors, time-aware summaries, and Plan B scenario callout text.
 
 - [`kit-advisory.ts`](./kit-advisory.ts)
   Rule-based kit recommendation logic shared across presenters. Builds photography equipment tips based on weather conditions.

--- a/src/presenters/shared/window-helpers.ts
+++ b/src/presenters/shared/window-helpers.ts
@@ -267,3 +267,11 @@ export function sessionRunnerUpLine(summary: SessionRecommendationSummary | unde
   if (primary.confidence !== 'low' && (primary.volatility ?? 0) < 20) return null;
   return `Runner-up: ${displaySessionName(runnerUp.session)} at ${runnerUp.hourLabel} (${runnerUp.score}/100).`;
 }
+
+/**
+ * Returns the plan-B scenario string from the session recommendation summary,
+ * or null when unavailable (high confidence or no runner-up).
+ */
+export function planBScenario(summary: SessionRecommendationSummary | undefined): string | null {
+  return summary?.planB ?? null;
+}

--- a/src/presenters/site/README.md
+++ b/src/presenters/site/README.md
@@ -37,7 +37,7 @@ Each section is a self-contained module that renders one visual area of the page
 | Signal Cards | `signals.ts` | Aurora, moon, sunset hue signal indicators |
 | Window | `window.ts` | Detailed shooting window display with hourly breakdown |
 | Daylight Utility | `daylight-utility.ts` | Sunrise/sunset timeline bar |
-| Session Recommendation | `session-rec.ts` | Recommended photography session card |
+| Session Recommendation | `session-rec.ts` | Recommended photography session card with Plan B callout |
 | Creative Spark | `creative-spark.ts` | AI-generated creative text section |
 | Kit Advisory | `kit-advisory.ts` | Photography equipment recommendations |
 | Alternatives | `alternatives.ts` | Nearby alternative locations comparison |

--- a/src/presenters/site/sections/session-rec.ts
+++ b/src/presenters/site/sections/session-rec.ts
@@ -5,6 +5,7 @@ import {
   sessionRecommendationHeadline,
   sessionRunnerUpLine,
   sessionVolatilityLabel,
+  planBScenario,
 } from '../../shared/window-helpers.js';
 import type { BriefRenderInput } from '../../../contracts/index.js';
 import { C } from '../../shared/brief-primitives.js';
@@ -27,6 +28,7 @@ export function sSessionRecommendationCard(input: SessionRecInput): string {
       : C.warning;
   const volatility = sessionVolatilityLabel(primary);
   const runnerUp = sessionRunnerUpLine(sessionRecommendation);
+  const planB = planBScenario(sessionRecommendation);
 
   return sCard(`
     <div class="card-overline">Best session today</div>
@@ -38,5 +40,6 @@ export function sSessionRecommendationCard(input: SessionRecInput): string {
     </div>
     <p class="card-body" style="margin-top:10px;">${esc(sessionRecommendationBody(primary))}</p>
     ${runnerUp ? `<p class="card-body" style="margin-top:8px;color:${C.subtle};">${esc(runnerUp)}</p>` : ''}
+    ${planB ? `<div class="plan-b-callout" style="margin-top:10px;padding:8px 10px;background:${C.surfaceAlt || '#f7f5f0'};border-radius:6px;font-size:0.85em;color:${C.muted};"><strong>Plan\u00a0B:</strong> ${esc(planB)}</div>` : ''}
   `, { accentSide: 'left', accentColor: scoreState(primary.score).fg });
 }

--- a/src/presenters/telegram/README.md
+++ b/src/presenters/telegram/README.md
@@ -12,7 +12,7 @@ This folder contains the Telegram message formatter. It transforms brief data in
 ## Public Entry Points
 
 - [`format-telegram.ts`](./format-telegram.ts)
-  `formatTelegram(input)` — Main entry point. Accepts `BriefRenderInput` and returns an HTML-formatted string for Telegram.
+  `formatTelegram(input)` — Main entry point. Accepts `BriefRenderInput` and returns an HTML-formatted string for Telegram. Includes Plan B scenario line when primary session confidence is not high.
 
 Exported types (re-exports from brief types):
 ```typescript

--- a/src/presenters/telegram/format-telegram.ts
+++ b/src/presenters/telegram/format-telegram.ts
@@ -9,6 +9,7 @@ import type {
   Window,
 } from '../../contracts/index.js';
 import { resolveHomeLatitude, resolveHomeLocationName } from '../../lib/home-location.js';
+import { planBScenario } from '../shared/window-helpers.js';
 
 export type {
   AltLocation,
@@ -142,10 +143,12 @@ export function formatTelegram(input: FormatTelegramInput): string {
 
   const lrLine = longRangeTelegram(longRangeTop, longRangeCardLabel, darkSkyAlert);
   const lrSection = lrLine ? `\n${DIV}${lrLine}\n` : '';
+  const planB = planBScenario(input.sessionRecommendation);
+  const planBLine = planB ? `\n\ud83d\udd04 <i>${planB}</i>\n` : '';
 
   if (dontBother) {
     return `\ud83d\udcf7 <b>${locationName} Photo Brief</b> \u2014 ${today}\n\ud83c\udf05 ${sunriseStr}  \ud83c\udf07 ${sunsetStr}  \ud83c\udf19 ${moonPct}% moon\n${shLine}${auroraLine}${metarNote ? metarNote + '\n' : ''}${DIV}\u274c <b>Not worth it today</b>  [${todayBestScore}/100]\n${aiText}\n\n\ud83d\udccd <b>Other places to consider today:</b>${altsTelegram(altLocations)}${lrSection}\n${DIV}<b>\ud83d\udcc5 Days Ahead</b>\n${photoFiveDayTelegram(dailySummary)}\n\n<b>\ud83d\ude97 Car Wash Forecast</b>\n${cwFiveDayTelegram(dailySummary)}`;
   }
 
-  return `\ud83d\udcf7 <b>${locationName} Photo Brief</b> \u2014 ${today}\n\ud83c\udf05 ${sunriseStr}  \ud83c\udf07 ${sunsetStr}  \ud83c\udf19 ${moonPct}% moon\n${shLine}${auroraLine}${metarNote ? metarNote + '\n' : ''}${DIV}${windowsTelegram(windows)}\n\n\ud83d\udcac <i>${aiText}</i>\n\n\ud83d\udccd <b>Other places to consider today:</b>${altsTelegram(altLocations)}${lrSection}\n${DIV}<b>\ud83d\udcc5 Days Ahead</b>\n${photoFiveDayTelegram(dailySummary)}\n\n<b>\ud83d\ude97 Car Wash Forecast</b>\n${cwFiveDayTelegram(dailySummary)}`;
+  return `\ud83d\udcf7 <b>${locationName} Photo Brief</b> \u2014 ${today}\n\ud83c\udf05 ${sunriseStr}  \ud83c\udf07 ${sunsetStr}  \ud83c\udf19 ${moonPct}% moon\n${shLine}${auroraLine}${metarNote ? metarNote + '\n' : ''}${DIV}${windowsTelegram(windows)}\n\n\ud83d\udcac <i>${aiText}</i>${planBLine}\n\n\ud83d\udccd <b>Other places to consider today:</b>${altsTelegram(altLocations)}${lrSection}\n${DIV}<b>\ud83d\udcc5 Days Ahead</b>\n${photoFiveDayTelegram(dailySummary)}\n\n<b>\ud83d\ude97 Car Wash Forecast</b>\n${cwFiveDayTelegram(dailySummary)}`;
 }

--- a/src/types/session-score.ts
+++ b/src/types/session-score.ts
@@ -94,6 +94,7 @@ export interface SessionRecommendationSummary {
   runnerUps: SessionRecommendation[];
   bySession: SessionRecommendation[];
   hoursAnalyzed: number;
+  planB: string | null;
 }
 
 export interface SessionEvaluator {


### PR DESCRIPTION
## Summary

Implements alternative-scenario framing for session recommendations. When the primary session has medium or low confidence, a "Plan B" string is generated from the top runner-up, giving photographers actionable fallback advice.

**Format:** `If [primary warning/risk]: consider [runner-up session] at [hour] — [runner-up reason]`

Closes #225

## Changes

### Type layer
- Added `planB: string | null` field to `SessionRecommendationSummary`

### Scoring domain
- `summarizeSessionRecommendations()` now generates a `planB` string when `primary.confidence !== "high"` and a runner-up exists
- Uses the primary warning as the "risk clause" and the runner-up first reason as the "why pivot"

### Editorial prompt
- Injected `planB` into the local-window prompt context facts so the LLM can weave the alternative scenario into its editorial text naturally

### Presenters
- **Email**: Plan B rendered as a styled callout block within the session recommendation card
- **Site**: Same treatment with site card primitives
- **Telegram**: Plan B rendered as a line after the AI editorial text
- **Shared**: Added `planBScenario()` helper for consistent access across presenters

### Documentation
- Updated READMEs for scoring, shared presenters, site, and telegram

## Testing
- All 486 existing tests pass (6 pre-existing file failures due to missing `astronomy-engine` dependency — unrelated)
- No TypeScript errors in any modified files