### PR TITLE
feat(#45): detect post-frontal clarity windows and wet-scavenged air

### DIFF
--- a/src/domain/README.md
+++ b/src/domain/README.md
@@ -38,7 +38,7 @@ This folder contains the business logic for weather scoring and editorial genera
   Orchestrates hourly scoring, day summaries, and session recommendation attachment.
 
 - `features/`
-  Hour-level feature engineering and weather metric derivation.
+  Hour-level feature engineering, weather metric derivation, and post-frontal clarity detection (multi-hour lookback for wet-scavenged air windows).
 
 - `sessions/`
   Built-in session evaluators (golden hour, blue hour, astro, etc.), cross-hour selection logic, and recommendation summary generation.

--- a/src/domain/scoring/README.md
+++ b/src/domain/scoring/README.md
@@ -29,6 +29,8 @@ This folder owns weather feature derivation, day scoring, and session recommenda
   Near-term (0-6h) nowcast signal computation. Currently supports satellite radiation clearing/thickening detection via Open-Meteo Satellite Radiation API (EUMETSAT).
 - `metar/`
   Structured METAR observation parsing. Extracts wx type (fog/mist/haze/smoke/rain/snow/thunderstorm), visibility, cloud base height, and dew-point spread from raw METAR strings using `metar-taf-parser`. Parsed fields are injected into `DerivedHourFeatures` for evaluator consumption.
+- `features/post-frontal-clarity.ts`
+  Post-frontal clarity detection. Identifies the transient 2–6 hour window of clean, high-contrast air following frontal passage by combining four signals: recent rain accumulation, wind direction shift, visibility jump, and humidity drop. Produces a 0–100 `postFrontalClarityScore` per hour and a day-level peak/window summary. Requires multi-hour lookback so is computed in `summarize-day.ts` and backfilled into feature inputs.
 - `score-all-days.ts`
   Orchestrates hourly scoring, day summaries, debug payload assembly, and session recommendation attachment.
 
@@ -47,6 +49,7 @@ This folder owns weather feature derivation, day scoring, and session recommenda
 - `features/derive-hour-features.ts` derives `diffuseToDirectRatio` (diffuse / (direct + 1)) and `hasFrost` (soil temp ≤ 0 °C) from raw radiation and soil temperature fields.
 - `features/derive-hour-features.ts` guards `sweetSpotScore` against division-by-zero when `idealMin === hardMin` or `idealMax === hardMax`.
 - `features/derive-hour-features.ts` derives `crepuscularScore` from three multiplicative Van Den Broeke sub-scores: geometry window (solar elevation −4° to 12°), occlusion + gap (broken/layered cloud with gaps), and beam visibility (AOD sweet-spot 0.10–0.30 with moderate humidity). The score is zero outside the geometry window. Previously this was an inline heuristic in `score-hour.ts`; it is now physics-informed and derived alongside other features.
+- `summarize-day.ts` runs post-frontal clarity detection after scoring all hours (multi-hour lookback required). Backfills `postFrontalClarityScore` into feature inputs and emits `postFrontalClarityPeak` / `postFrontalClarityWindow` on `DaySummary`. Returns `null` when insufficient lookback data is available (< 3 hours).
 
 ## What not to edit casually
 
@@ -61,3 +64,4 @@ This folder owns weather feature derivation, day scoring, and session recommenda
 - [`sessions/index.test.ts`](./sessions/index.test.ts)
 - [`nowcast/satellite-clearing.test.ts`](./nowcast/satellite-clearing.test.ts)
 - [`metar/parse-metar.test.ts`](./metar/parse-metar.test.ts)
+- [`features/post-frontal-clarity.test.ts`](./features/post-frontal-clarity.test.ts)

--- a/src/domain/scoring/contracts.ts
+++ b/src/domain/scoring/contracts.ts
@@ -216,4 +216,6 @@ export interface DaySummary {
   bestPmHour: string;
   sunriseOcclusionRisk: number | null;
   sunsetOcclusionRisk: number | null;
+  postFrontalClarityPeak: number;
+  postFrontalClarityWindow: string | null;
 }

--- a/src/domain/scoring/daily/summarize-day.ts
+++ b/src/domain/scoring/daily/summarize-day.ts
@@ -17,6 +17,7 @@ import { computeConfidence, type EnsEntry } from './confidence.js';
 import { computeCarWash } from './car-wash.js';
 import { computeTwilightBoundaries } from './twilight.js';
 import type { ParsedMetar } from '../metar/parse-metar.js';
+import { detectPostFrontalClarity, findPostFrontalClarityPeak, type HourSlice } from '../features/post-frontal-clarity.js';
 
 interface DateEntry { ts: string; i: number }
 
@@ -182,6 +183,34 @@ export function summarizeDay(p: SummarizeDayParams): DaySummary {
     console.warn(`[Summarize Day] Coalesced null air quality values to defaults for ${aqNullCount} hours on ${dateKey}.`);
   }
 
+  // ── Post-frontal clarity detection (multi-hour lookback) ──────────────────
+  const hourSlices: HourSlice[] = (byDate[dateKey] || []).map(({ ts, i }) => ({
+    ts,
+    precipMm: w.hourly!.precipitation?.[i] ?? 0,
+    precipProbPct: ppIdx[ts] != null && ppIdx[ts] >= 0
+      ? (ppData.hourly!.precipitation_probability?.[ppIdx[ts]] ?? 0)
+      : 0,
+    visibilityKm: (w.hourly!.visibility?.[i] ?? 10000) / 1000,
+    humidityPct: w.hourly!.relativehumidity_2m?.[i] ?? 70,
+    windDirectionDeg: w.hourly!.winddirection_10m?.[i] ?? null,
+    aerosolOpticalDepth: (() => {
+      const qi = aqIdx[ts] ?? -1;
+      return qi >= 0 ? (aqData.hourly!.aerosol_optical_depth?.[qi] ?? 0.2) : 0.2;
+    })(),
+  }));
+
+  const { peakScore: postFrontalClarityPeak, windowLabel: postFrontalClarityWindow } =
+    findPostFrontalClarityPeak(hourSlices);
+
+  // Backfill post-frontal clarity scores into feature inputs
+  hourSlices.forEach((slice, idx) => {
+    const result = detectPostFrontalClarity(hourSlices, idx);
+    const ts = slice.ts;
+    if (featureInputsByTs[ts]) {
+      featureInputsByTs[ts].postFrontalClarityScore = result?.score ?? null;
+    }
+  });
+
   // Best photo score - apply duration bonus at the day level
   const goldenHours = hours.filter(h => h.isGolden || h.isBlue);
   const photoHours  = goldenHours.length ? goldenHours : hours.filter(h => !h.isNight);
@@ -251,5 +280,7 @@ export function summarizeDay(p: SummarizeDayParams): DaySummary {
     bestAmHour: bestAmH.hour || '\u2014', bestPmHour: bestPmH.hour || '\u2014',
     sunriseOcclusionRisk: sunriseOcclusionRisk !== null ? Math.round(sunriseOcclusionRisk) : null,
     sunsetOcclusionRisk: sunsetOcclusionRisk !== null ? Math.round(sunsetOcclusionRisk) : null,
+    postFrontalClarityPeak,
+    postFrontalClarityWindow,
   };
 }

--- a/src/domain/scoring/features/post-frontal-clarity.test.ts
+++ b/src/domain/scoring/features/post-frontal-clarity.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectPostFrontalClarity,
+  findPostFrontalClarityPeak,
+  type HourSlice,
+} from './post-frontal-clarity.js';
+
+function makeHour(overrides: Partial<HourSlice> & { ts: string }): HourSlice {
+  return {
+    precipMm: 0,
+    precipProbPct: 0,
+    visibilityKm: 15,
+    humidityPct: 70,
+    windDirectionDeg: 180,
+    aerosolOpticalDepth: 0.15,
+    ...overrides,
+  };
+}
+
+function makeTimestamp(baseDate: string, hourOffset: number): string {
+  const d = new Date(baseDate);
+  d.setUTCHours(d.getUTCHours() + hourOffset);
+  return d.toISOString().replace(/:\d{2}\.\d{3}Z$/, ':00');
+}
+
+describe('detectPostFrontalClarity', () => {
+  it('returns null when insufficient lookback hours', () => {
+    const hours = [
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 0) }),
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 1) }),
+    ];
+    expect(detectPostFrontalClarity(hours, 1)).toBeNull();
+  });
+
+  it('returns score 0 when current hour is still raining', () => {
+    const hours = Array.from({ length: 7 }, (_, i) =>
+      makeHour({
+        ts: makeTimestamp('2026-04-05T06:00:00Z', i),
+        precipMm: i < 4 ? 1 : 0,
+        precipProbPct: i < 6 ? 30 : 0,
+        humidityPct: 85,
+      }),
+    );
+    // Hour 5 still has precip prob > 10%
+    const result = detectPostFrontalClarity(hours, 5);
+    expect(result).not.toBeNull();
+    expect(result!.score).toBe(0);
+  });
+
+  it('returns score 0 when no recent rain', () => {
+    const hours = Array.from({ length: 7 }, (_, i) =>
+      makeHour({
+        ts: makeTimestamp('2026-04-05T06:00:00Z', i),
+        precipMm: 0,
+        visibilityKm: 30,
+        humidityPct: 50,
+      }),
+    );
+    const result = detectPostFrontalClarity(hours, 6);
+    expect(result).not.toBeNull();
+    expect(result!.score).toBe(0);
+  });
+
+  it('detects classic post-frontal clarity: rain → clear, wind shift, vis jump, humidity drop', () => {
+    const hours: HourSlice[] = [
+      // Hours 0-3: rain period (4 hours of 2mm/h = 8mm total)
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 0), precipMm: 2, precipProbPct: 80, humidityPct: 92, visibilityKm: 5, windDirectionDeg: 200 }),
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 1), precipMm: 2, precipProbPct: 70, humidityPct: 90, visibilityKm: 6, windDirectionDeg: 210 }),
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 2), precipMm: 2, precipProbPct: 50, humidityPct: 88, visibilityKm: 8, windDirectionDeg: 220 }),
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 3), precipMm: 1, precipProbPct: 30, humidityPct: 82, visibilityKm: 12, windDirectionDeg: 240 }),
+      // Hour 4: transition
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 4), precipMm: 0, precipProbPct: 8, humidityPct: 65, visibilityKm: 22, windDirectionDeg: 280 }),
+      // Hour 5: post-frontal clarity window
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 5), precipMm: 0, precipProbPct: 3, humidityPct: 52, visibilityKm: 32, windDirectionDeg: 300, aerosolOpticalDepth: 0.03 }),
+      // Hour 6: still in clarity window
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 6), precipMm: 0, precipProbPct: 5, humidityPct: 48, visibilityKm: 35, windDirectionDeg: 310, aerosolOpticalDepth: 0.04 }),
+    ];
+
+    const result5 = detectPostFrontalClarity(hours, 5);
+    expect(result5).not.toBeNull();
+    expect(result5!.score).toBeGreaterThan(50);
+    expect(result5!.recentRainMm).toBeGreaterThanOrEqual(2);
+
+    const result6 = detectPostFrontalClarity(hours, 6);
+    expect(result6).not.toBeNull();
+    expect(result6!.score).toBeGreaterThan(40);
+  });
+
+  it('scores lower when only rain + visibility signals present (no wind shift or humidity drop)', () => {
+    const hours: HourSlice[] = [
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 0), precipMm: 3, precipProbPct: 80, humidityPct: 70, visibilityKm: 8, windDirectionDeg: 180 }),
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 1), precipMm: 2, precipProbPct: 60, humidityPct: 70, visibilityKm: 10, windDirectionDeg: 180 }),
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 2), precipMm: 1, precipProbPct: 30, humidityPct: 70, visibilityKm: 15, windDirectionDeg: 180 }),
+      // Post-rain but no wind shift and humidity stays the same
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 3), precipMm: 0, precipProbPct: 5, humidityPct: 68, visibilityKm: 28, windDirectionDeg: 185 }),
+    ];
+
+    const result = detectPostFrontalClarity(hours, 3);
+    expect(result).not.toBeNull();
+    // Some score from rain + visibility, but weaker without wind shift + humidity
+    expect(result!.score).toBeGreaterThan(0);
+    expect(result!.score).toBeLessThan(60);
+  });
+
+  it('returns null when wind direction is unavailable for all hours', () => {
+    const hours: HourSlice[] = Array.from({ length: 6 }, (_, i) =>
+      makeHour({
+        ts: makeTimestamp('2026-04-05T06:00:00Z', i),
+        precipMm: i < 3 ? 2 : 0,
+        precipProbPct: i < 3 ? 70 : 5,
+        humidityPct: i < 3 ? 90 : 50,
+        visibilityKm: i < 3 ? 5 : 30,
+        windDirectionDeg: null,
+      }),
+    );
+
+    const result = detectPostFrontalClarity(hours, 5);
+    expect(result).not.toBeNull();
+    // Should still produce a score (wind shift defaults to neutral 50)
+    expect(result!.score).toBeGreaterThan(0);
+    expect(result!.windShiftDeg).toBeNull();
+  });
+
+  it('handles AOD bonus for very clean post-rain air', () => {
+    const hours: HourSlice[] = [
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 0), precipMm: 3, precipProbPct: 80, humidityPct: 92, visibilityKm: 5 }),
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 1), precipMm: 2, precipProbPct: 60, humidityPct: 88, visibilityKm: 8 }),
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 2), precipMm: 1, precipProbPct: 30, humidityPct: 80, visibilityKm: 15 }),
+      // Very clean air: AOD below 0.05 threshold
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', 3), precipMm: 0, precipProbPct: 5, humidityPct: 50, visibilityKm: 30, aerosolOpticalDepth: 0.03 }),
+    ];
+
+    const resultClean = detectPostFrontalClarity(hours, 3)!;
+
+    // Same scenario but with normal AOD
+    hours[3] = makeHour({
+      ts: makeTimestamp('2026-04-05T06:00:00Z', 3),
+      precipMm: 0, precipProbPct: 5, humidityPct: 50, visibilityKm: 30, aerosolOpticalDepth: 0.20,
+    });
+    const resultNormal = detectPostFrontalClarity(hours, 3)!;
+
+    expect(resultClean.score).toBeGreaterThanOrEqual(resultNormal.score);
+  });
+});
+
+describe('findPostFrontalClarityPeak', () => {
+  it('returns peakScore 0 and null window when no post-frontal event', () => {
+    const hours = Array.from({ length: 8 }, (_, i) =>
+      makeHour({ ts: makeTimestamp('2026-04-05T06:00:00Z', i), precipMm: 0, visibilityKm: 15, humidityPct: 65 }),
+    );
+    const { peakScore, windowLabel } = findPostFrontalClarityPeak(hours);
+    expect(peakScore).toBe(0);
+    expect(windowLabel).toBeNull();
+  });
+
+  it('finds peak and window for a classic post-frontal event', () => {
+    const hours: HourSlice[] = [
+      makeHour({ ts: '2026-04-05T06:00:00', precipMm: 3, precipProbPct: 80, humidityPct: 92, visibilityKm: 4, windDirectionDeg: 200 }),
+      makeHour({ ts: '2026-04-05T07:00:00', precipMm: 3, precipProbPct: 70, humidityPct: 90, visibilityKm: 5, windDirectionDeg: 210 }),
+      makeHour({ ts: '2026-04-05T08:00:00', precipMm: 2, precipProbPct: 50, humidityPct: 85, visibilityKm: 8, windDirectionDeg: 220 }),
+      makeHour({ ts: '2026-04-05T09:00:00', precipMm: 1, precipProbPct: 20, humidityPct: 75, visibilityKm: 15, windDirectionDeg: 250 }),
+      makeHour({ ts: '2026-04-05T10:00:00', precipMm: 0, precipProbPct: 5, humidityPct: 55, visibilityKm: 30, windDirectionDeg: 290, aerosolOpticalDepth: 0.04 }),
+      makeHour({ ts: '2026-04-05T11:00:00', precipMm: 0, precipProbPct: 3, humidityPct: 48, visibilityKm: 35, windDirectionDeg: 300, aerosolOpticalDepth: 0.03 }),
+      makeHour({ ts: '2026-04-05T12:00:00', precipMm: 0, precipProbPct: 5, humidityPct: 50, visibilityKm: 32, windDirectionDeg: 310, aerosolOpticalDepth: 0.04 }),
+    ];
+
+    const { peakScore, windowLabel } = findPostFrontalClarityPeak(hours);
+    expect(peakScore).toBeGreaterThan(30);
+    expect(windowLabel).not.toBeNull();
+  });
+});

--- a/src/domain/scoring/features/post-frontal-clarity.ts
+++ b/src/domain/scoring/features/post-frontal-clarity.ts
@@ -1,0 +1,199 @@
+import { clamp } from '../../../lib/utils.js';
+
+/**
+ * Post-frontal clarity detection.
+ *
+ * Detects the transient window of clean, high-contrast air that often follows
+ * frontal passage. Wet scavenging by rain removes aerosols and particulates,
+ * producing exceptional visibility for 2–6 hours before new aerosol/humidity
+ * loading rebuilds.
+ *
+ * Four signals are combined (all must be partially present for a non-zero score):
+ *   1. Recent rain — precip accumulation > 2mm in prior 3–6h, now stopped
+ *   2. Wind shift — direction change > 45° across the rain/clear boundary
+ *   3. Visibility jump — visibility climbing above 25km (wet-scavenged air)
+ *   4. Humidity drop — RH falling below 60% after being > 80% during rain
+ */
+
+export interface HourSlice {
+  ts: string;
+  precipMm: number;
+  precipProbPct: number;
+  visibilityKm: number;
+  humidityPct: number;
+  windDirectionDeg: number | null;
+  aerosolOpticalDepth: number;
+}
+
+export interface PostFrontalClarityResult {
+  score: number;
+  recentRainMm: number;
+  windShiftDeg: number | null;
+  visibilityKm: number;
+  humidityPct: number;
+  priorHumidityPct: number;
+}
+
+const LOOKBACK_HOURS = 6;
+const MIN_LOOKBACK_HOURS = 3;
+const RAIN_THRESHOLD_MM = 2;
+const PRECIP_PROB_CLEAR_PCT = 10;
+const WIND_SHIFT_THRESHOLD_DEG = 45;
+const VISIBILITY_THRESHOLD_KM = 25;
+const HUMIDITY_CLEAR_PCT = 60;
+const HUMIDITY_RAIN_PCT = 80;
+const AOD_WASHED_THRESHOLD = 0.05;
+
+function angularDifference(a: number, b: number): number {
+  const diff = Math.abs(a - b) % 360;
+  return diff > 180 ? 360 - diff : diff;
+}
+
+function averageWindDirection(directions: (number | null)[]): number | null {
+  const valid = directions.filter((d): d is number => d != null);
+  if (valid.length === 0) return null;
+  // Vector average to handle wraparound
+  const sinSum = valid.reduce((s, d) => s + Math.sin((d * Math.PI) / 180), 0);
+  const cosSum = valid.reduce((s, d) => s + Math.cos((d * Math.PI) / 180), 0);
+  const avg = (Math.atan2(sinSum / valid.length, cosSum / valid.length) * 180) / Math.PI;
+  return ((avg % 360) + 360) % 360;
+}
+
+/**
+ * Detect post-frontal clarity for a single hour.
+ *
+ * @param hours  All hours for the day, in chronological order.
+ * @param currentIdx  Index of the hour to evaluate.
+ * @returns Clarity result with 0–100 score, or null if insufficient lookback data.
+ */
+export function detectPostFrontalClarity(
+  hours: HourSlice[],
+  currentIdx: number,
+): PostFrontalClarityResult | null {
+  if (currentIdx < MIN_LOOKBACK_HOURS) return null;
+
+  const current = hours[currentIdx];
+
+  // Current hour must not be raining
+  if (current.precipProbPct > PRECIP_PROB_CLEAR_PCT) {
+    return { score: 0, recentRainMm: 0, windShiftDeg: null, visibilityKm: current.visibilityKm, humidityPct: current.humidityPct, priorHumidityPct: 0 };
+  }
+
+  // Lookback window: prior 3–6 hours
+  const lookbackStart = Math.max(0, currentIdx - LOOKBACK_HOURS);
+  const lookbackEnd = currentIdx; // exclusive
+  const priorHours = hours.slice(lookbackStart, lookbackEnd);
+
+  if (priorHours.length < MIN_LOOKBACK_HOURS) return null;
+
+  // ── Signal 1: Recent rain ────────────────────────────────────────────────
+  const recentRainMm = priorHours.reduce((sum, h) => sum + h.precipMm, 0);
+  const rainSignal = recentRainMm >= RAIN_THRESHOLD_MM
+    ? clamp(Math.round(((recentRainMm - RAIN_THRESHOLD_MM) / 6) * 100), 0, 100)
+    : 0;
+
+  // Must have meaningful recent rain — this is the gating signal
+  if (rainSignal === 0) {
+    return { score: 0, recentRainMm, windShiftDeg: null, visibilityKm: current.visibilityKm, humidityPct: current.humidityPct, priorHumidityPct: 0 };
+  }
+
+  // ── Signal 2: Wind shift ─────────────────────────────────────────────────
+  // Compare average wind direction during rain period vs current hour
+  const rainHourDirs = priorHours
+    .filter(h => h.precipMm > 0)
+    .map(h => h.windDirectionDeg);
+  const priorAvgDir = averageWindDirection(rainHourDirs);
+  const windShiftDeg = (priorAvgDir != null && current.windDirectionDeg != null)
+    ? angularDifference(priorAvgDir, current.windDirectionDeg)
+    : null;
+
+  const windShiftSignal = windShiftDeg != null
+    ? clamp(Math.round(((windShiftDeg - 20) / (WIND_SHIFT_THRESHOLD_DEG - 20)) * 100), 0, 100)
+    : 50; // neutral when wind direction unavailable
+
+  // ── Signal 3: Visibility jump ────────────────────────────────────────────
+  const visSignal = current.visibilityKm >= VISIBILITY_THRESHOLD_KM
+    ? clamp(Math.round(((current.visibilityKm - 20) / 15) * 100), 0, 100)
+    : clamp(Math.round(((current.visibilityKm - 10) / 15) * 60), 0, 60);
+
+  // AOD bonus: very clean air post-washout
+  const aodBonus = current.aerosolOpticalDepth <= AOD_WASHED_THRESHOLD
+    ? 20
+    : current.aerosolOpticalDepth <= 0.10
+      ? 10
+      : 0;
+
+  const visibilitySignal = clamp(visSignal + aodBonus);
+
+  // ── Signal 4: Humidity drop ──────────────────────────────────────────────
+  const priorHumidities = priorHours.map(h => h.humidityPct);
+  const maxPriorHumidity = Math.max(...priorHumidities);
+  const humidityDrop = maxPriorHumidity - current.humidityPct;
+
+  const humiditySignal = (maxPriorHumidity >= HUMIDITY_RAIN_PCT && current.humidityPct <= HUMIDITY_CLEAR_PCT)
+    ? clamp(Math.round((humidityDrop / 40) * 100), 0, 100)
+    : (maxPriorHumidity >= 70 && current.humidityPct <= 65)
+      ? clamp(Math.round((humidityDrop / 40) * 60), 0, 60)
+      : 0;
+
+  // ── Composite score ──────────────────────────────────────────────────────
+  // Rain is the gating signal (35%). Other signals modulate the score.
+  // All signals should contribute for a strong detection.
+  const composite = Math.round(
+    (rainSignal * 0.35)
+    + (windShiftSignal * 0.15)
+    + (visibilitySignal * 0.30)
+    + (humiditySignal * 0.20),
+  );
+
+  // Apply a minimum-signal gate: at least 2 of the 4 signals must be non-zero
+  const activeSignals = [rainSignal, windShiftSignal, visibilitySignal, humiditySignal]
+    .filter(s => s > 0).length;
+  const gatedScore = activeSignals >= 2 ? clamp(composite) : 0;
+
+  return {
+    score: gatedScore,
+    recentRainMm,
+    windShiftDeg: windShiftDeg != null ? Math.round(windShiftDeg) : null,
+    visibilityKm: current.visibilityKm,
+    humidityPct: current.humidityPct,
+    priorHumidityPct: Math.round(maxPriorHumidity),
+  };
+}
+
+/**
+ * Find the peak post-frontal clarity window across all hours in a day.
+ */
+export function findPostFrontalClarityPeak(
+  hours: HourSlice[],
+): { peakScore: number; windowLabel: string | null } {
+  let peakScore = 0;
+  let windowStart: string | null = null;
+  let windowEnd: string | null = null;
+
+  const ALERT_THRESHOLD = 30;
+
+  for (let i = 0; i < hours.length; i++) {
+    const result = detectPostFrontalClarity(hours, i);
+    if (result && result.score > peakScore) {
+      peakScore = result.score;
+    }
+    if (result && result.score >= ALERT_THRESHOLD) {
+      const hourLabel = new Date(hours[i].ts).toLocaleTimeString('en-GB', {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone: 'UTC',
+      });
+      if (!windowStart) windowStart = hourLabel;
+      windowEnd = hourLabel;
+    }
+  }
+
+  const windowLabel = windowStart && windowEnd
+    ? windowStart === windowEnd
+      ? windowStart
+      : `${windowStart}–${windowEnd}`
+    : null;
+
+  return { peakScore, windowLabel };
+}

--- a/src/types/session-score.ts
+++ b/src/types/session-score.ts
@@ -75,6 +75,7 @@ export interface DerivedHourFeatures {
   metarCloudBaseM?: number | null;
   metarDewPointSpreadC?: number | null;
   visibilityDeltaVsModelKm?: number | null;
+  postFrontalClarityScore?: number | null;
 }
 
 export interface SessionScore {


### PR DESCRIPTION
## Summary

Implements heuristic event detection for the transient 2–6 hour window of clean, high-contrast air that follows frontal passage. Wet scavenging by rain removes aerosols and particulates, producing exceptional visibility — a condition most photographers miss because they see "was raining" and move on.

Closes #45

## Changes

### New: `src/domain/scoring/features/post-frontal-clarity.ts`
Four-signal detection heuristic combining:
1. **Recent rain** — accumulation > 2mm in prior 3–6h, now stopped (precip_prob < 10%)
2. **Wind shift** — direction change > 45° between rain period and current hour (vector-averaged)
3. **Visibility jump** — visibility climbing above 25km with AOD washout bonus (< 0.05)
4. **Humidity drop** — RH falling below 60% after being > 80% during rain

Composite 0–100 score with rain as gating signal (35%), visibility (30%), humidity (20%), wind shift (15%). Minimum 2 active signals required for non-zero output.

`findPostFrontalClarityPeak()` scans all hours to find peak score and window label.

### Modified: `src/types/session-score.ts`
- Added optional `postFrontalClarityScore` field to `DerivedHourFeatures`

### Modified: `src/domain/scoring/contracts.ts`
- Added `postFrontalClarityPeak: number` and `postFrontalClarityWindow: string | null` to `DaySummary`

### Modified: `src/domain/scoring/daily/summarize-day.ts`
- Runs post-frontal clarity detection after scoring all hours (multi-hour lookback)
- Backfills `postFrontalClarityScore` into feature inputs (same pattern as METAR/ensemble backfill)
- Emits day-level peak and window on `DaySummary`

### Documentation
- Updated `src/domain/scoring/README.md` — new module, defensive guard, test entry
- Updated `src/domain/README.md` — features directory description

## Design Decisions
- **Modifier, not session**: Represented as a derived feature score and day-level alert, not a new session evaluator (per issue guidance)
- **Multi-hour lookback in summarize-day**: Detection requires prior 3–6h context, which single-hour `deriveHourFeatures()` cannot provide. Backfill pattern matches METAR and ensemble fields.
- **No new connectors**: All inputs (precipitation, wind direction, visibility, humidity, AOD) already fetched
- **Graceful degradation**: Returns null when < 3 hours of lookback available; wind shift defaults to neutral 50 when wind direction absent

## Testing
- 9 new unit tests in `post-frontal-clarity.test.ts` covering: insufficient lookback, still raining, no rain, classic detection, partial signals, null wind direction, AOD bonus, peak/window finding
- All 20 feature tests pass (11 derive-hour-features + 9 post-frontal-clarity)
- No TypeScript errors in modified files