### PR TITLE
fix: replace non-existent surfaceAlt token with surfaceVariant

### DIFF
--- a/src/presenters/email/sections/session-recommendation.ts
+++ b/src/presenters/email/sections/session-recommendation.ts
@@ -53,6 +53,6 @@ export function sessionRecommendationCard(sessionRecommendation: FormatEmailInpu
     </div>
     <div style="Margin-top:10px;font-family:${FONT};font-size:13px;line-height:1.5;color:${C.muted};">${esc(sessionRecommendationBody(primary))}</div>
     ${runnerUp ? `<div style="Margin-top:8px;font-family:${FONT};font-size:12px;line-height:1.5;color:${C.subtle};">${esc(runnerUp)}</div>` : ''}
-    ${planB ? `<div style="Margin-top:10px;padding:8px 10px;background:${C.surfaceAlt || '#f7f5f0'};border-radius:6px;font-family:${FONT};font-size:12px;line-height:1.5;color:${C.muted};"><strong>Plan\u00a0B:</strong> ${esc(planB)}</div>` : ''}
+    ${planB ? `<div style="Margin-top:10px;padding:8px 10px;background:${C.surfaceVariant};border-radius:6px;font-family:${FONT};font-size:12px;line-height:1.5;color:${C.muted};"><strong>Plan\u00a0B:</strong> ${esc(planB)}</div>` : ''}
   `, '', `border-left:3px solid ${scoreState(primary.score).fg};`);
 }

--- a/src/presenters/site/sections/session-rec.ts
+++ b/src/presenters/site/sections/session-rec.ts
@@ -51,6 +51,6 @@ export function sSessionRecommendationCard(input: SessionRecInput): string {
     </div>
     <p class="card-body" style="margin-top:10px;">${esc(sessionRecommendationBody(primary))}</p>
     ${runnerUp ? `<p class="card-body" style="margin-top:8px;color:${C.subtle};">${esc(runnerUp)}</p>` : ''}
-    ${planB ? `<div class="plan-b-callout" style="margin-top:10px;padding:8px 10px;background:${C.surfaceAlt || '#f7f5f0'};border-radius:6px;font-size:0.85em;color:${C.muted};"><strong>Plan\u00a0B:</strong> ${esc(planB)}</div>` : ''}
+    ${planB ? `<div class="plan-b-callout" style="margin-top:10px;padding:8px 10px;background:${C.surfaceVariant};border-radius:6px;font-size:0.85em;color:${C.muted};"><strong>Plan\u00a0B:</strong> ${esc(planB)}</div>` : ''}
   `, { accentSide: 'left', accentColor: scoreState(primary.score).fg });
 }


### PR DESCRIPTION
Closes #242

## What

Replaces `C.surfaceAlt || '#f7f5f0'` with `C.surfaceVariant` in both presenter files:
- `src/presenters/email/sections/session-recommendation.ts`
- `src/presenters/site/sections/session-rec.ts`

## Why

`surfaceAlt` doesn't exist in the color tokens. The correct token is `surfaceVariant` (`#f4efe8`). The fallback is no longer needed since the token is always defined.

## Verification

`npx tsc --noEmit` — both errors resolved.