### PR TITLE
fix: add marine and nowcastSatellite to assemble test expected output

### DIFF
--- a/workflow/build/assemble.test.ts
+++ b/workflow/build/assemble.test.ts
@@ -164,6 +164,8 @@ describe('workflow assembly', () => {
         precipProb: { hourly: { time: ['2026-03-14T06:00'], precipitation_probability: [10] } },
         ensemble: { hourly: { time: ['2026-03-14T06:00'], cloudcover_member_0: [25] } },
         azimuthByPhase: { sunrise: { '2026-03-14T06:15': { occlusionRisk: 12 } }, sunset: {} },
+        nowcastSatellite: undefined,
+        marine: { hourly: { time: [] } },
       },
     }]);
   });


### PR DESCRIPTION
Closes #244

## What

Adds `nowcastSatellite: undefined` and `marine: { hourly: { time: [] } }` to the expected output in the 'assembles retry-safe score input packaging' test.

## Why

`build-score-input.adapter.ts` always emits these fields with defaults. The test expectation was missing them, causing a deep-equality failure in CI.

## Verification

- `npx vitest run workflow/build/assemble.test.ts` — all 17 tests pass
- `npx tsc --noEmit` — clean