### PR TITLE
fix: opt into Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/deploy-n8n.yml
+++ b/.github/workflows/deploy-n8n.yml
@@ -30,6 +30,9 @@ concurrency:
   group: deploy-n8n
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: Test & build


### PR DESCRIPTION
Closes #246

## What

Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as a top-level `env` in `deploy-n8n.yml`.

## Why

All actions (`checkout@v4`, `setup-node@v4`, `upload-artifact@v4`, `download-artifact@v4`, `setup-python@v5`) currently run on Node.js 20 which is deprecated. Node.js 24 becomes mandatory June 2nd 2026. This opts in early to eliminate the warnings.