### PR TITLE
feat: add alt-location scoring to dump-pipeline script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ dist/
 # Generated artifacts - built in CI
 generated/workflow/photography-weather-brief.json
 src/presenters/email/compiled-layout.generated.ts
-scripts/*

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,33 @@
+# Scripts
+
+Local development and debugging scripts for the Aperture pipeline.
+
+## dump-pipeline.ts
+
+Replays an API snapshot through the scoring pipeline and writes each stage's output to `debug/pipeline-dump-<timestamp>/`.
+
+**Usage:**
+
+```bash
+npm run cli:dump-pipeline            # uses most recent snapshot
+npx ts-node scripts/dump-pipeline.ts debug/api-snapshot-<timestamp>  # specific snapshot
+```
+
+**Stages dumped:**
+
+| File | Stage | Description |
+|------|-------|-------------|
+| `01-normalized-inputs.json` | 1 | Adapter-normalized payloads (what scoring sees) |
+| `02-scoring-output.json` | 2 | `scoreAllDays()` result (hours, daily summary, sessions) |
+| `02b-alt-scoring-output.json` | 2b | `scoreAlternatives()` result (alt locations, close contenders) |
+| `03-editorial-context.json` | 3 | Scored context that feeds the editorial prompt builder |
+
+Alt-location scoring (Stage 2b) discovers `alt-weather-*` snapshot files dynamically and matches them to the location registry in `src/lib/prepare-alt-locations.ts`.
+
+## snapshot-apis.sh
+
+Captures live API responses into a timestamped `debug/api-snapshot-*` directory for offline replay by `dump-pipeline.ts`.
+
+## esm-compat-loader.mjs
+
+Custom Node.js loader for ESM/TypeScript compatibility when running scripts directly.

--- a/scripts/dump-pipeline.ts
+++ b/scripts/dump-pipeline.ts
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/**
+ * dump-pipeline.ts — Replay an API snapshot through the Aperture pipeline
+ * and write each stage's output to debug/pipeline-dump-<timestamp>/
+ *
+ * Stages dumped:
+ *   01-normalized-inputs.json   — adapter-normalized payloads (what scoring sees)
+ *   02-scoring-output.json      — scoreAllDays() result (hours, daily summary, sessions)
+ *   02b-alt-scoring-output.json — scoreAlternatives() result (alt locations, contenders)
+ *   03-editorial-request.json   — prompt + context sent to AI providers
+ *
+ * Usage:
+ *   node --loader ts-node/esm scripts/dump-pipeline.ts [snapshot-dir]
+ *
+ * If snapshot-dir is omitted, uses the most recent debug/api-snapshot-* directory.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'fs';
+import { resolve, join, basename } from 'path';
+
+// Domain
+import { scoreAllDays } from '../src/domain/scoring/score-all-days.js';
+import { scoreAlternatives } from '../src/domain/scoring/score-alternatives.js';
+
+// Lib — alt locations
+import { prepareAltLocations } from '../src/lib/prepare-alt-locations.js';
+
+// Lib — aurora parsing
+import {
+  parseAuroraWatchUK,
+  parseNasaDonkiCme,
+  fuseAuroraSignals,
+} from '../src/lib/aurora-providers.js';
+
+// Config defaults
+import { DEFAULT_HOME_LOCATION } from '../src/lib/home-location.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function extractJsonFromMd(filePath: string): unknown {
+  const raw = readFileSync(filePath, 'utf-8');
+  // Extract content between first ``` and last ```
+  const match = raw.match(/```\n?([\s\S]*?)```/);
+  if (!match) {
+    console.warn(`  ⚠ No fenced code block in ${basename(filePath)}`);
+    return null;
+  }
+  const body = match[1].trim();
+  if (!body) return null;
+
+  // Try JSON parse; if it's XML (aurorawatch), return raw string
+  try {
+    return JSON.parse(body);
+  } catch {
+    return body; // raw text (XML etc.)
+  }
+}
+
+function findLatestSnapshot(debugDir: string): string {
+  const entries = readdirSync(debugDir)
+    .filter(e => e.startsWith('api-snapshot-'))
+    .map(e => ({ name: e, mtime: statSync(join(debugDir, e)).mtime.getTime() }))
+    .sort((a, b) => b.mtime - a.mtime);
+
+  if (entries.length === 0) {
+    throw new Error(`No api-snapshot-* directories found in ${debugDir}`);
+  }
+  return join(debugDir, entries[0].name);
+}
+
+function parseKpRows(raw: unknown): Array<{ time: string; kp: number }> {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((row): row is Record<string, unknown> =>
+      row != null && typeof row === 'object' && 'time_tag' in row && 'kp' in row,
+    )
+    .map(row => ({
+      time: String(row.time_tag),
+      kp: typeof row.kp === 'number' ? row.kp : parseFloat(String(row.kp)),
+    }))
+    .filter(r => !isNaN(r.kp));
+}
+
+function writeStage(dir: string, filename: string, data: unknown): void {
+  const path = join(dir, filename);
+  writeFileSync(path, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  const size = statSync(path).size;
+  const sizeStr = size > 1024 * 1024
+    ? `${(size / 1024 / 1024).toFixed(1)}MB`
+    : size > 1024
+      ? `${(size / 1024).toFixed(0)}KB`
+      : `${size}B`;
+  console.log(`  ✓ ${filename} (${sizeStr})`);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+function main() {
+  const debugDir = resolve('debug');
+  const snapshotDir = process.argv[2]
+    ? resolve(process.argv[2])
+    : findLatestSnapshot(debugDir);
+
+  console.log(`Snapshot: ${snapshotDir}`);
+
+  // Derive timestamp from directory name
+  const dirName = basename(snapshotDir);
+  const stamp = dirName.replace('api-snapshot-', '');
+  const outDir = join(debugDir, `pipeline-dump-${stamp}`);
+  mkdirSync(outDir, { recursive: true });
+
+  console.log(`Output:   ${outDir}/\n`);
+
+  // ── Load raw API responses ──────────────────────────────────────────────
+
+  const allFiles = readdirSync(snapshotDir).filter(f => f.endsWith('.md')).sort();
+
+  function findFile(substring: string): string | undefined {
+    const match = allFiles.find(f => f.includes(substring));
+    return match ? join(snapshotDir, match) : undefined;
+  }
+
+  function loadFile(substring: string): unknown {
+    const path = findFile(substring);
+    if (!path) {
+      console.warn(`  ⚠ No file matching "${substring}" in snapshot`);
+      return null;
+    }
+    return extractJsonFromMd(path);
+  }
+
+  const raw = {
+    weather:     loadFile('weather-ukmo'),
+    airQuality:  loadFile('air-quality'),
+    metar:       loadFile('metar'),
+    sunsetHue:   loadFile('sunsethue'),
+    precipProb:  loadFile('precip-prob'),
+    ensemble:    loadFile('ensemble'),
+    azimuth:     loadFile('azimuth'),
+    kpIndex:     loadFile('kp-index'),
+    auroraWatch: loadFile('aurorawatch'),
+    nasaDonki:   loadFile('nasa-donki'),
+  };
+
+  // ── Stage 1: Normalize (replicate adapter layer) ────────────────────────
+
+  console.log('Stage 1: Normalizing inputs...');
+
+  const EMPTY_HOURLY = { hourly: { time: [] as string[] } };
+  const EMPTY_WEATHER = { hourly: { time: [] as string[] }, daily: { sunrise: [] as string[], sunset: [] as string[], moonrise: [] as string[], moonset: [] as string[] } };
+
+  const weather     = raw.weather ?? EMPTY_WEATHER;
+  const airQuality  = raw.airQuality ?? EMPTY_HOURLY;
+  const metarRaw    = Array.isArray(raw.metar) ? raw.metar : [];
+  const sunsetHueRaw = raw.sunsetHue as any;
+  const sunsetHue   = Array.isArray(sunsetHueRaw?.data)
+    ? sunsetHueRaw.data
+    : (Array.isArray(sunsetHueRaw) ? sunsetHueRaw : []);
+  const precipProb  = raw.precipProb ?? EMPTY_HOURLY;
+  const ensemble    = raw.ensemble ?? EMPTY_HOURLY;
+  const kpForecast  = parseKpRows(raw.kpIndex);
+
+  // Aurora: parse from raw provider responses
+  const nearTermAurora = parseAuroraWatchUK(raw.auroraWatch);
+  const longRangeAurora = parseNasaDonkiCme(raw.nasaDonki);
+  const auroraSignal = fuseAuroraSignals(nearTermAurora, longRangeAurora);
+
+  // Azimuth: the snapshot only has one sample point (25km west).
+  // In the real pipeline, prepare-azimuth generates multiple sample points and
+  // aggregate-azimuth merges them. We pass an empty azimuthByPhase here since
+  // we can't reconstruct the full multi-point scan from a single sample.
+  const azimuthByPhase = {};
+
+  const normalizedInputs = {
+    weather,
+    airQuality,
+    metarRaw,
+    sunsetHue,
+    precipProb,
+    ensemble,
+    azimuthByPhase,
+    kpForecast,
+    auroraSignal,
+  };
+
+  writeStage(outDir, '01-normalized-inputs.json', normalizedInputs);
+
+  // ── Stage 2: Score ──────────────────────────────────────────────────────
+
+  console.log('Stage 2: Running scoreAllDays...');
+
+  const scoreResult = scoreAllDays({
+    lat: DEFAULT_HOME_LOCATION.lat,
+    lon: DEFAULT_HOME_LOCATION.lon,
+    timezone: DEFAULT_HOME_LOCATION.timezone,
+    weather: weather as any,
+    airQuality: airQuality as any,
+    precipProb: precipProb as any,
+    metarRaw: metarRaw as any,
+    sunsetHue: sunsetHue as any,
+    ensemble: ensemble as any,
+    azimuthByPhase: azimuthByPhase as any,
+  });
+
+  // Extract the serializable parts (debugContext can be large)
+  const scoringOutput = {
+    todayHours: scoreResult.todayHours,
+    dailySummary: scoreResult.dailySummary,
+    metarNote: scoreResult.metarNote,
+    sessionRecommendation: scoreResult.sessionRecommendation,
+    debugContext: {
+      metadata: scoreResult.debugContext.metadata,
+      hourlyScoring: scoreResult.debugContext.hourlyScoring,
+      windows: scoreResult.debugContext.windows,
+      // Omit payloadSnapshots (huge) — they're in the normalized-inputs file
+    },
+  };
+
+  writeStage(outDir, '02-scoring-output.json', scoringOutput);
+
+  // ── Stage 2b: Score alternative locations ────────────────────────────────
+
+  console.log('Stage 2b: Scoring alt locations...');
+
+  const altLocationMeta = prepareAltLocations(DEFAULT_HOME_LOCATION.timezone);
+
+  // Discover alt-weather snapshot files dynamically
+  const altWeatherFiles = allFiles.filter(f => f.includes('alt-weather-'));
+
+  const altWeatherData = altLocationMeta.map(loc => {
+    const slug = loc.name.toLowerCase().replace(/\s+/g, '-');
+    const file = altWeatherFiles.find(f => f.includes(`alt-weather-${slug}`));
+    if (!file) return null;
+    return extractJsonFromMd(join(snapshotDir, file));
+  }).filter(Boolean);
+
+  // Build a location meta list matching only the locations we have data for
+  const matchedAltMeta = altLocationMeta.filter(loc => {
+    const slug = loc.name.toLowerCase().replace(/\s+/g, '-');
+    return altWeatherFiles.some(f => f.includes(`alt-weather-${slug}`));
+  });
+
+  const altResult = scoreAlternatives({
+    altWeatherData: altWeatherData as any[],
+    altLocationMeta: matchedAltMeta,
+    homeContext: {
+      dailySummary: scoreResult.dailySummary,
+      todayBestScore: scoreResult.todayHours.reduce((max, h) => Math.max(max, h.score), 0),
+      debugContext: scoreResult.debugContext,
+      windows: scoreResult.debugContext.windows,
+      dontBother: false,
+      todayCarWash: false,
+      metarNote: scoreResult.metarNote,
+      sunrise: null,
+      sunset: null,
+      moonPct: null,
+    },
+  });
+
+  const altScoringOutput = {
+    altLocations: altResult.altLocations,
+    closeContenders: altResult.closeContenders,
+    noAltsMsg: altResult.noAltsMsg,
+    augmentedSummary: altResult.augmentedSummary,
+    snapshotFilesMatched: altWeatherFiles,
+    locationsScored: matchedAltMeta.map(l => l.name),
+  };
+
+  writeStage(outDir, '02b-alt-scoring-output.json', altScoringOutput);
+
+  // ── Stage 3: Editorial request context ──────────────────────────────────
+
+  console.log('Stage 3: Building editorial request context...');
+
+  // The editorial request is built from scored context. We capture what would
+  // be sent as the editorial prompt context (the key fields the AI sees).
+  const editorialContext = {
+    _note: 'This is the scored context that feeds the editorial prompt builder. The actual prompt text is generated at runtime by src/domain/editorial/.',
+    dailySummary: scoreResult.dailySummary,
+    todayHours: scoreResult.todayHours.map(h => ({
+      hour: h.hour,
+      score: h.score,
+      ct: h.ct,
+      visK: h.visK,
+      aod: h.aod,
+    })),
+    sessionRecommendation: scoreResult.sessionRecommendation,
+    metarNote: scoreResult.metarNote,
+    aurora: auroraSignal,
+    kpForecast: kpForecast.slice(0, 10), // first few for context
+    location: DEFAULT_HOME_LOCATION,
+    altLocations: altResult.altLocations,
+    closeContenders: altResult.closeContenders,
+    noAltsMsg: altResult.noAltsMsg,
+  };
+
+  writeStage(outDir, '03-editorial-context.json', editorialContext);
+
+  console.log(`\nDone. 4 pipeline stages dumped to ${outDir}/`);
+}
+
+main();

--- a/scripts/esm-compat-loader.mjs
+++ b/scripts/esm-compat-loader.mjs
@@ -1,0 +1,20 @@
+/**
+ * Custom ESM loader that fixes CJS/ESM interop for dual-format packages.
+ * On Node ≥ 22, ts-node resolves astronomy-engine to its ESM entry but
+ * still marks it as CJS, breaking named imports. This loader forces the
+ * correct module format.
+ *
+ * Usage: node --loader ts-node/esm --loader ./scripts/esm-compat-loader.mjs <script>
+ */
+
+const ESM_PACKAGES = new Set([
+  'astronomy-engine',
+]);
+
+export async function resolve(specifier, context, nextResolve) {
+  if (ESM_PACKAGES.has(specifier)) {
+    const resolved = await nextResolve(specifier, context);
+    return { ...resolved, format: 'module' };
+  }
+  return nextResolve(specifier, context);
+}

--- a/scripts/snapshot-apis.sh
+++ b/scripts/snapshot-apis.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# snapshot-apis.sh — Fetch all Aperture API endpoints and save responses
+# as numbered markdown files in debug/api-snapshot-<timestamp>/
+#
+# Usage:
+#   ./scripts/snapshot-apis.sh
+#   LAT=54.0 LON=-2.1 LOCATION=Malham ./scripts/snapshot-apis.sh
+#
+# Environment variables (all optional, defaults to Leeds):
+#   LAT          — latitude  (default: 53.82703)
+#   LON          — longitude (default: -1.570755)
+#   TIMEZONE     — timezone  (default: Europe/London)
+#   ICAO         — METAR station (default: EGNM)
+#   NASA_API_KEY — NASA DONKI key (default: DEMO_KEY)
+#   SUNSETHUE_API_KEY — SunsetHue key (default: empty, header omitted)
+
+set -euo pipefail
+
+# Source keys from home .env if available and not already set
+ENV_FILE="${ENV_FILE:-$HOME/Documents/vscode/home/.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+LAT="${PHOTO_WEATHER_LAT:-${LAT:-53.82703}}"
+LON="${PHOTO_WEATHER_LON:-${LON:--1.570755}}"
+TIMEZONE="${PHOTO_WEATHER_TIMEZONE:-${TIMEZONE:-Europe/London}}"
+ICAO="${PHOTO_WEATHER_ICAO:-${ICAO:-EGNM}}"
+NASA_API_KEY="${NASA_API_KEY:-DEMO_KEY}"
+SUNSETHUE_API_KEY="${SUNSETHUE_API_KEY:-}"
+
+TZ_ENC=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$TIMEZONE'))")
+
+STAMP=$(date -u +%Y-%m-%dT%H%M%S)
+DIR="debug/api-snapshot-${STAMP}"
+mkdir -p "$DIR"
+
+# NASA DONKI date range: 3 days ago to 4 days ahead
+if [[ "$(uname)" == "Darwin" ]]; then
+  DONKI_START=$(date -u -v-3d +%Y-%m-%d)
+  DONKI_END=$(date -u -v+4d +%Y-%m-%d)
+else
+  DONKI_START=$(date -u -d '-3 days' +%Y-%m-%d)
+  DONKI_END=$(date -u -d '+4 days' +%Y-%m-%d)
+fi
+
+# Azimuth sample point: 25km west (approximate)
+AZ_LAT=$(python3 -c "print(round($LAT, 4))")
+AZ_LON=$(python3 -c "
+import math
+lat_r = math.radians($LAT)
+lon_r = math.radians($LON)
+d = 25 / 6371
+brng = math.radians(270)
+lat2 = math.asin(math.sin(lat_r)*math.cos(d) + math.cos(lat_r)*math.sin(d)*math.cos(brng))
+lon2 = lon_r + math.atan2(math.sin(brng)*math.sin(d)*math.cos(lat_r), math.cos(d)-math.sin(lat_r)*math.sin(lat2))
+print(round(math.degrees(lon2), 4))
+")
+
+# Alt location: first nearby alternative (Malham Cove hardcoded as representative)
+ALT_LAT="${ALT_LAT:-54.069}"
+ALT_LON="${ALT_LON:--2.158}"
+ALT_NAME="${ALT_NAME:-Malham Cove}"
+
+# ─── API definitions ─────────────────────────────────────────────────────────
+# Each entry: number|label|url
+APIS=(
+  "01|Weather (UKMO)|https://api.open-meteo.com/v1/forecast?latitude=${LAT}&longitude=${LON}&models=ukmo_seamless&hourly=cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,visibility,temperature_2m,relativehumidity_2m,dewpoint_2m,precipitation,windspeed_10m,windgusts_10m,winddirection_10m,cape,vapour_pressure_deficit&daily=sunrise,sunset&timezone=${TZ_ENC}&forecast_days=5"
+  "02|Air Quality|https://air-quality-api.open-meteo.com/v1/air-quality?latitude=${LAT}&longitude=${LON}&hourly=aerosol_optical_depth,dust,uv_index,european_aqi,pm2_5,alder_pollen,birch_pollen,grass_pollen&timezone=${TZ_ENC}&forecast_days=5"
+  "03|METAR (${ICAO})|https://aviationweather.gov/api/data/metar?ids=${ICAO}&format=json&taf=false"
+  "04|SunsetHue|https://api.sunsethue.com/forecast?latitude=${LAT}&longitude=${LON}"
+  "05|Precip Prob|https://api.open-meteo.com/v1/forecast?latitude=${LAT}&longitude=${LON}&hourly=precipitation_probability,lightning_potential&timezone=${TZ_ENC}&forecast_days=5"
+  "06|Ensemble|https://ensemble-api.open-meteo.com/v1/ensemble?latitude=${LAT}&longitude=${LON}&hourly=cloudcover&models=ecmwf_ifs025&timezone=${TZ_ENC}&forecast_days=5"
+  "07|Alt Weather (${ALT_NAME})|https://api.open-meteo.com/v1/forecast?latitude=${ALT_LAT}&longitude=${ALT_LON}&models=ukmo_seamless&hourly=cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,visibility,temperature_2m,relativehumidity_2m,dewpoint_2m,precipitation_probability,precipitation,windspeed_10m,windgusts_10m,total_column_integrated_water_vapour,snowfall,snow_depth&daily=sunrise,sunset&timezone=${TZ_ENC}&forecast_days=5"
+  "08|Long Range Weather (${ALT_NAME})|https://api.open-meteo.com/v1/forecast?latitude=${ALT_LAT}&longitude=${ALT_LON}&models=ukmo_seamless&hourly=cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,visibility,temperature_2m,relativehumidity_2m,dewpoint_2m,precipitation_probability,precipitation,windspeed_10m,windgusts_10m,total_column_integrated_water_vapour&daily=sunrise,sunset&timezone=${TZ_ENC}&forecast_days=1"
+  "09|Azimuth Weather (25km west)|https://api.open-meteo.com/v1/forecast?latitude=${AZ_LAT}&longitude=${AZ_LON}&hourly=cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,precipitation_probability,precipitation,visibility,windspeed_10m&timezone=${TZ_ENC}&forecast_days=5"
+  "10|Kp Index|https://services.swpc.noaa.gov/products/noaa-planetary-k-index-forecast.json"
+  "11|AuroraWatch UK|https://aurorawatch.lancs.ac.uk/api/0.1/status/"
+  "12|NASA DONKI CME|https://api.nasa.gov/DONKI/CME?startDate=${DONKI_START}&endDate=${DONKI_END}&api_key=${NASA_API_KEY}"
+)
+
+echo "Snapshot → ${DIR}/"
+echo "Location: lat=${LAT} lon=${LON} tz=${TIMEZONE} icao=${ICAO}"
+echo ""
+
+for entry in "${APIS[@]}"; do
+  IFS='|' read -r num label url <<< "$entry"
+  file="${DIR}/${num}-$(echo "$label" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/-$//').md"
+
+  echo -n "  ${num} ${label} ... "
+
+  # Build curl args
+  CURL_ARGS=(-s -w '\n%{http_code}' --max-time 30)
+
+  # Add SunsetHue API key header if available
+  if [[ "$label" == "SunsetHue" && -n "$SUNSETHUE_API_KEY" ]]; then
+    CURL_ARGS+=(-H "x-api-key: ${SUNSETHUE_API_KEY}")
+  fi
+
+  # Fetch
+  RESPONSE=$(curl "${CURL_ARGS[@]}" "$url" 2>/dev/null || echo -e "\nERROR")
+  HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+  BODY=$(echo "$RESPONSE" | sed '$d')
+
+  # Detect content type for formatting
+  if echo "$BODY" | head -c1 | grep -q '<'; then
+    LANG=""
+  else
+    LANG=""
+  fi
+
+  # Write markdown
+  cat > "$file" <<EOF
+# HTTP: ${label} — ${STAMP}
+
+**URL:** \`${url}\`
+**HTTP status:** ${HTTP_CODE}
+
+\`\`\`
+${BODY}
+\`\`\`
+EOF
+
+  echo "${HTTP_CODE} → $(basename "$file")"
+
+  # Small delay to be polite to rate-limited APIs
+  sleep 0.3
+done
+
+echo ""
+echo "Done. ${#APIS[@]} snapshots saved to ${DIR}/"


### PR DESCRIPTION
Closes #249

## What

Adds alt-location scoring (Stage 2b) to `scripts/dump-pipeline.ts` so the debug pipeline dump includes alternative location recommendations. Also un-ignores and tracks `scripts/` in git.

## Why

The dump-pipeline script only ran `scoreAllDays()` for the home location. It never called `scoreAlternatives()`, so `altLocations` was always empty in the editorial context. This made it impossible to debug whether alt-location recommendations (e.g. "conditions look better at Malham") would appear in the real pipeline.

## Changes

- **`scripts/dump-pipeline.ts`** — Added Stage 2b:
  - Imports `scoreAlternatives` and `prepareAltLocations`
  - Dynamically discovers `alt-weather-*` snapshot files and matches them to the location registry
  - Calls `scoreAlternatives()` with home context from `scoreAllDays()`
  - Writes `02b-alt-scoring-output.json` with full alt scoring results
  - Includes `altLocations`, `closeContenders`, and `noAltsMsg` in the editorial context (Stage 3)
- **`.gitignore`** — Removed `scripts/*` exclusion so scripts are tracked in git
- **`scripts/README.md`** — New README documenting all scripts and pipeline stages

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — all 658 tests pass
