### PR TITLE
fix: count imminent CMEs from stale DONKI data when arrival <24h away

### DIFF
--- a/src/lib/aurora-providers.test.ts
+++ b/src/lib/aurora-providers.test.ts
@@ -314,6 +314,41 @@ describe('fuseAuroraSignals', () => {
     expect(signal.upcomingCmeCount).toBe(0);
   });
 
+  it('counts imminent CME from stale data when arrival is within 24h', () => {
+    const now = new Date('2026-04-05T14:00Z');
+    const signal = fuseAuroraSignals(null, {
+      isStale: true,
+      fetchedAt: '2026-04-05T01:48Z',
+      earthDirectedCmes: [{
+        activityId: 'test-cme',
+        startTime: '2026-04-02T20:46Z',
+        estimatedArrivalTime: '2026-04-05T20:00Z', // 6h away
+        estimatedKp: 4,
+        note: 'Earth directed.',
+      }],
+    }, now);
+    expect(signal.upcomingCmeCount).toBe(1);
+    expect(signal.nextCmeArrival).toBe('2026-04-05T20:00Z');
+    expect(signal.dominantLevel).toBe('yellow');
+    expect(signal.confidence).toBe('low');
+  });
+
+  it('does NOT count stale CME when arrival is >24h away', () => {
+    const now = new Date('2026-04-05T14:00Z');
+    const signal = fuseAuroraSignals(null, {
+      isStale: true,
+      fetchedAt: '2026-04-04T01:00Z',
+      earthDirectedCmes: [{
+        activityId: 'test-cme',
+        startTime: '2026-04-02T20:46Z',
+        estimatedArrivalTime: '2026-04-07T20:00Z', // 2 days away
+        estimatedKp: 4,
+        note: 'Earth directed.',
+      }],
+    }, now);
+    expect(signal.upcomingCmeCount).toBe(0);
+  });
+
   it('surfaces both near-term and long-range data on the signal object', () => {
     const nearTerm = makeNearTerm('red');
     const longRange = makeLongRange([makeCme(48)]);

--- a/src/lib/aurora-providers.ts
+++ b/src/lib/aurora-providers.ts
@@ -266,12 +266,26 @@ export function fuseAuroraSignals(
   // Count upcoming Earth-directed CMEs (arriving within lookahead window).
   // Stale long-range data is not surfaced — we can't trust arrival windows.
   const freshLongRange = longRange && !longRange.isStale ? longRange : null;
-  const upcomingCmes = (freshLongRange?.earthDirectedCmes ?? []).filter(cme => {
+  const freshUpcoming = (freshLongRange?.earthDirectedCmes ?? []).filter(cme => {
     if (!cme.estimatedArrivalTime) return false;
     const arrival = new Date(cme.estimatedArrivalTime).getTime();
     const diff = arrival - now.getTime();
     return diff >= 0 && diff <= DONKI_LOOKAHEAD_MS;
   });
+
+  // Fallback: also count CMEs from stale data if arrival is imminent (<24h away).
+  // CME arrival estimates are stable enough that 12-24h-old data is still
+  // actionable for imminent arrivals — photographers shouldn't miss tonight's aurora.
+  const IMMINENT_WINDOW_MS = 24 * 60 * 60 * 1000;
+  const imminentFromStale = (longRange?.isStale ? (longRange.earthDirectedCmes ?? []) : [])
+    .filter(cme => {
+      if (!cme.estimatedArrivalTime) return false;
+      const arrival = new Date(cme.estimatedArrivalTime).getTime();
+      const diff = arrival - now.getTime();
+      return diff >= 0 && diff <= IMMINENT_WINDOW_MS;
+    });
+
+  const upcomingCmes = freshUpcoming.length > 0 ? freshUpcoming : imminentFromStale;
 
   const nextCmeArrival = upcomingCmes[0]?.estimatedArrivalTime ?? null;
   const upcomingCmeCount = upcomingCmes.length;
@@ -281,7 +295,7 @@ export function fuseAuroraSignals(
   let horizon: AuroraSignal['horizon'] = 'none';
 
   const nearTermLevel = nearTerm && !nearTerm.isStale ? nearTerm.level : null;
-  const hasUpcomingCme = upcomingCmeCount > 0 && !(longRange?.isStale ?? true);
+  const hasUpcomingCme = upcomingCmeCount > 0;
 
   if (nearTermLevel && nearTermLevel !== 'green') {
     // Active alert (yellow/amber/red) — near-term drives


### PR DESCRIPTION
Closes #250

## What

`fuseAuroraSignals()` in `src/lib/aurora-providers.ts` now counts imminent CMEs from stale DONKI data when the estimated arrival is within 24 hours.

## Why

The staleness check was binary — 12-hour-old data was treated the same as 7-day-old data. A CME arriving in 6 hours from 12-hour-old DONKI data is still highly actionable. Photographers were missing potential aurora opportunities because `upcomingCmeCount` was silently set to 0.

## Changes

- **`src/lib/aurora-providers.ts`** — Added `imminentFromStale` fallback in `fuseAuroraSignals()`:
  - Fresh CMEs (96h lookahead) are preferred when available
  - Falls back to stale CMEs only when arrival is within 24h (`IMMINENT_WINDOW_MS`)
  - Updated `hasUpcomingCme` to derive from `upcomingCmeCount > 0` (the imminent filter validates trustworthiness)
  - Confidence logic unchanged — stale long-range still yields `'low'` or `'medium'` confidence, never `'high'`

- **`src/lib/aurora-providers.test.ts`** — Two new test cases:
  - Counts imminent CME from stale data when arrival is within 24h (expects count=1, dominantLevel='yellow', confidence='low')
  - Does NOT count stale CME when arrival is >24h away (expects count=0)

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — all 660 tests pass
