### PR TITLE
fix: deduplicate long-range locations already covered by alt-weather pipeline

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,7 +26,7 @@ Alt-location scoring (Stage 2b) discovers `alt-weather-*` snapshot files dynamic
 
 ## snapshot-apis.sh
 
-Captures live API responses into a timestamped `debug/api-snapshot-*` directory for offline replay by `dump-pipeline.ts`.
+Captures live API responses into a timestamped `debug/api-snapshot-*` directory for offline replay by `dump-pipeline.ts`. The snapshot covers 11 endpoints (items 01–11). A redundant 1-day long-range call for the representative alt-location was removed in #251 — the 5-day alt-weather response is a strict superset.
 
 ## esm-compat-loader.mjs
 

--- a/scripts/snapshot-apis.sh
+++ b/scripts/snapshot-apis.sh
@@ -73,11 +73,10 @@ APIS=(
   "05|Precip Prob|https://api.open-meteo.com/v1/forecast?latitude=${LAT}&longitude=${LON}&hourly=precipitation_probability,lightning_potential&timezone=${TZ_ENC}&forecast_days=5"
   "06|Ensemble|https://ensemble-api.open-meteo.com/v1/ensemble?latitude=${LAT}&longitude=${LON}&hourly=cloudcover&models=ecmwf_ifs025&timezone=${TZ_ENC}&forecast_days=5"
   "07|Alt Weather (${ALT_NAME})|https://api.open-meteo.com/v1/forecast?latitude=${ALT_LAT}&longitude=${ALT_LON}&models=ukmo_seamless&hourly=cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,visibility,temperature_2m,relativehumidity_2m,dewpoint_2m,precipitation_probability,precipitation,windspeed_10m,windgusts_10m,total_column_integrated_water_vapour,snowfall,snow_depth&daily=sunrise,sunset&timezone=${TZ_ENC}&forecast_days=5"
-  "08|Long Range Weather (${ALT_NAME})|https://api.open-meteo.com/v1/forecast?latitude=${ALT_LAT}&longitude=${ALT_LON}&models=ukmo_seamless&hourly=cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,visibility,temperature_2m,relativehumidity_2m,dewpoint_2m,precipitation_probability,precipitation,windspeed_10m,windgusts_10m,total_column_integrated_water_vapour&daily=sunrise,sunset&timezone=${TZ_ENC}&forecast_days=1"
-  "09|Azimuth Weather (25km west)|https://api.open-meteo.com/v1/forecast?latitude=${AZ_LAT}&longitude=${AZ_LON}&hourly=cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,precipitation_probability,precipitation,visibility,windspeed_10m&timezone=${TZ_ENC}&forecast_days=5"
-  "10|Kp Index|https://services.swpc.noaa.gov/products/noaa-planetary-k-index-forecast.json"
-  "11|AuroraWatch UK|https://aurorawatch.lancs.ac.uk/api/0.1/status/"
-  "12|NASA DONKI CME|https://api.nasa.gov/DONKI/CME?startDate=${DONKI_START}&endDate=${DONKI_END}&api_key=${NASA_API_KEY}"
+  "08|Azimuth Weather (25km west)|https://api.open-meteo.com/v1/forecast?latitude=${AZ_LAT}&longitude=${AZ_LON}&hourly=cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,precipitation_probability,precipitation,visibility,windspeed_10m&timezone=${TZ_ENC}&forecast_days=5"
+  "09|Kp Index|https://services.swpc.noaa.gov/products/noaa-planetary-k-index-forecast.json"
+  "10|AuroraWatch UK|https://aurorawatch.lancs.ac.uk/api/0.1/status/"
+  "11|NASA DONKI CME|https://api.nasa.gov/DONKI/CME?startDate=${DONKI_START}&endDate=${DONKI_END}&api_key=${NASA_API_KEY}"
 )
 
 echo "Snapshot → ${DIR}/"

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -30,7 +30,7 @@ This folder is the canonical infrastructure layer: shared utilities, astronomy h
 - [`long-range-locations.ts`](./long-range-locations.ts) — canonical long-range location registry with drive-time helpers.
 - [`prepare-alt-locations.ts`](./prepare-alt-locations.ts) — alt-location registry with Open-Meteo URL builder.
 - [`prepare-marine.ts`](./prepare-marine.ts) — URL builder for the Open-Meteo Marine API (wave height, direction, period, peak period) for coastal seascape scoring.
-- [`prepare-long-range.ts`](./prepare-long-range.ts) — filters and enriches long-range locations with forecast URLs.
+- [`prepare-long-range.ts`](./prepare-long-range.ts) — filters and enriches long-range locations with forecast URLs. Deduplicates locations already covered by the alt-weather pipeline (within 2 km).
 - [`prepare-azimuth.ts`](./prepare-azimuth.ts) — generates azimuth sample points for sunrise/sunset horizon scans.
 - [`aggregate-azimuth.ts`](./aggregate-azimuth.ts) — aggregates multi-distance azimuth scan results into horizon metrics.
 

--- a/src/lib/prepare-locations.test.ts
+++ b/src/lib/prepare-locations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { prepareAltLocations } from './prepare-alt-locations.js';
+import { ALT_LOCATIONS, prepareAltLocations } from './prepare-alt-locations.js';
 import { prepareLongRangeLocations } from './prepare-long-range.js';
+import { haversineKm } from './long-range-locations.js';
 
 describe('forecast URL builders', () => {
   it('keeps alt location requests on supported Open-Meteo daily fields', () => {
@@ -44,6 +45,28 @@ describe('forecast URL builders', () => {
     for (const location of locations) {
       expect(location.url).toContain('models=ukmo_seamless');
       expect(location.url).not.toContain('precipitation_probability');
+    }
+  });
+
+  it('excludes long-range locations that overlap with alt-locations', () => {
+    const longRange = prepareLongRangeLocations('Europe/London');
+    const longRangeNames = longRange.map(l => l.name);
+
+    // These locations exist in both registries at identical coordinates
+    const knownOverlaps = ['Ribblehead Viaduct', 'Mam Tor', 'Stanage Edge', 'Ladybower Reservoir', 'Sutton Bank'];
+    for (const name of knownOverlaps) {
+      expect(longRangeNames).not.toContain(name);
+    }
+  });
+
+  it('verifies no long-range location is within 2 km of an alt-location', () => {
+    const longRange = prepareLongRangeLocations('Europe/London');
+
+    for (const lr of longRange) {
+      for (const alt of ALT_LOCATIONS) {
+        const km = haversineKm(lr.lat, lr.lon, alt.lat, alt.lon);
+        expect(km, `${lr.name} is ${km.toFixed(1)} km from alt-location ${alt.name}`).toBeGreaterThanOrEqual(2);
+      }
     }
   });
 });

--- a/src/lib/prepare-long-range.ts
+++ b/src/lib/prepare-long-range.ts
@@ -2,13 +2,19 @@ import {
   LONG_RANGE_LOCATIONS,
   isWithinDriveLimit,
   estimatedDriveMins,
+  haversineKm,
   type LongRangeLocation,
   type LocationTag,
   type Region,
 } from './long-range-locations.js';
+import { ALT_LOCATIONS } from './prepare-alt-locations.js';
 import type { SiteDarkness } from './site-darkness.js';
 import type { HomeLocation } from '../contracts/home-location.js';
 import { DEFAULT_HOME_LOCATION } from './home-location.js';
+
+/** Locations within this radius of an alt-location are already covered by the
+ *  5-day alt-weather pipeline and don't need a separate long-range API call. */
+const ALT_DEDUP_RADIUS_KM = 2;
 
 export interface LongRangeLocationWithUrl {
   name: string;
@@ -31,8 +37,20 @@ const HOURLY_FIELDS = [
 ].join(',');
 
 /**
+ * Returns true if a long-range location is within ALT_DEDUP_RADIUS_KM of any
+ * alt-location (which already receives a 5-day forecast).
+ */
+function isCoveredByAltLocation(loc: LongRangeLocation): boolean {
+  return ALT_LOCATIONS.some(
+    alt => haversineKm(loc.lat, loc.lon, alt.lat, alt.lon) < ALT_DEDUP_RADIUS_KM,
+  );
+}
+
+/**
  * Returns long-range locations within the 4-hour drive limit,
  * each enriched with an Open-Meteo forecast URL and estimated drive time.
+ * Locations already covered by an alt-location (within 2 km) are excluded
+ * to avoid redundant API calls — those are scored via the alt-weather pipeline.
  */
 export function prepareLongRangeLocations(
   timezone: string,
@@ -41,6 +59,7 @@ export function prepareLongRangeLocations(
   const tz = encodeURIComponent(timezone);
   return LONG_RANGE_LOCATIONS
     .filter(loc => isWithinDriveLimit(loc, homeLocation))
+    .filter(loc => !isCoveredByAltLocation(loc))
     .map(loc => ({
       name: loc.name,
       lat: loc.lat,


### PR DESCRIPTION
## Summary

Closes #251

`prepareLongRangeLocations()` now filters out any long-range location within 2 km (haversine) of an alt-location, eliminating redundant Open-Meteo API calls. The 5-day alt-weather response is a strict field superset of the 1-day long-range call.

## Changes

### `src/lib/prepare-long-range.ts`
- Imports `ALT_LOCATIONS` and `haversineKm`
- Adds `isCoveredByAltLocation()` helper using 2 km dedup radius
- Filters overlapping locations before URL generation

### `scripts/snapshot-apis.sh`
- Removes item `08|Long Range Weather` (redundant 1-day Malham call)
- Renumbers items 09–12 → 08–11

### `src/lib/prepare-locations.test.ts`
- Adds test: known overlapping names excluded from long-range output
- Adds test: no long-range location is within 2 km of any alt-location

### READMEs
- `src/lib/README.md` — notes dedup in `prepare-long-range.ts` description
- `scripts/README.md` — documents removal of redundant snapshot call

## Impact
- **Saves up to 7 HTTP requests per pipeline run** (5 exact duplicates + 2 near-matches)
- Zero user-facing behaviour change — overlapping locations still scored via alt-weather pipeline
- All 545 tests pass