### PR TITLE
fix: astroConfidence() now considers moon altitude, not just illumination

### DIFF
--- a/src/domain/scoring/sessions/index.test.ts
+++ b/src/domain/scoring/sessions/index.test.ts
@@ -367,6 +367,27 @@ describe('session scoring foundation', () => {
     expect(degraded.confidence).not.toBe('high');
   });
 
+  it('does not penalise astro confidence when bright moon is below the horizon', () => {
+    const moonAbove = evaluateSessionFeatures('astro', deriveHourFeatures(makeHour({
+      isNight: true, astroScore: 80, cloudTotalPct: 5, cloudLowPct: 2, cloudMidPct: 2, cloudHighPct: 1,
+      visibilityKm: 30, humidityPct: 50, aerosolOpticalDepth: 0.05, moonIlluminationPct: 93,
+      moonAltitudeDeg: 40, seeingScore: 75, lightPollutionBortle: 3,
+    })));
+    const moonBelow = evaluateSessionFeatures('astro', deriveHourFeatures(makeHour({
+      isNight: true, astroScore: 80, cloudTotalPct: 5, cloudLowPct: 2, cloudMidPct: 2, cloudHighPct: 1,
+      visibilityKm: 30, humidityPct: 50, aerosolOpticalDepth: 0.05, moonIlluminationPct: 93,
+      moonAltitudeDeg: -15, seeingScore: 75, lightPollutionBortle: 3,
+    })));
+
+    // With moon above horizon at 93% illumination, base is false → tighter spread thresholds
+    // moonBelow should get better confidence since moon alt ≤ -6° makes moonOk = true → base = true
+    expect(moonBelow.confidence).not.toBe('low');
+    expect(['medium', 'low']).toContain(moonAbove.confidence);
+    // The key assertion: moonBelow confidence should be strictly better than moonAbove
+    const rank = { low: 0, medium: 1, high: 2 } as const;
+    expect(rank[moonBelow.confidence]).toBeGreaterThan(rank[moonAbove.confidence]);
+  });
+
   it('applies a graduated twilight ramp between nautical and astronomical darkness', () => {
     const fullDark = evaluateSessionFeatures('astro', deriveHourFeatures(makeHour({
       isNight: true, astroScore: 80, cloudTotalPct: 8, cloudLowPct: 3, cloudMidPct: 3, cloudHighPct: 2,

--- a/src/domain/scoring/sessions/shared.ts
+++ b/src/domain/scoring/sessions/shared.ts
@@ -167,8 +167,13 @@ export function astroConfidence(features: DerivedHourFeatures, hardPass: boolean
   const spread = spreadVolatility(features);
   const seeingOk = features.seeingScore == null || features.seeingScore >= 50;
   const bortleOk = features.lightPollutionBortle == null || features.lightPollutionBortle <= 5;
+  // Moon is not a confidence concern if it's well below the horizon (≤ -6°),
+  // consistent with the astro evaluator's 5-band Krisciunas–Schaefer table
+  // where altitude ≤ -6° yields a moonAltFactor of 0.00.
+  const moonBelowHorizon = features.moonAltitudeDeg != null && features.moonAltitudeDeg <= -6;
+  const moonOk = features.moonIlluminationPct <= 30 || moonBelowHorizon;
   const base = features.cloudTotalPct <= 15
-    && features.moonIlluminationPct <= 30
+    && moonOk
     && features.transparencyScore >= 65
     && (features.hazeTrapRisk == null || features.hazeTrapRisk <= 55)
     && seeingOk


### PR DESCRIPTION
## Summary

Closes #252

`astroConfidence()` in `src/domain/scoring/sessions/shared.ts` previously used only `moonIlluminationPct <= 30` to gate the `base` condition. A bright moon (e.g. 93%) always forced `base = false` — producing pessimistic confidence — even when the moon was well below the horizon and contributing zero sky-glow.

## Root cause

The astro evaluator already handles this correctly via a 5-band Krisciunas–Schaefer altitude factor table (where alt ≤ -6° → factor 0.00), but `astroConfidence()` only checked illumination percentage.

## Fix

Added moon altitude awareness:

```ts
const moonBelowHorizon = features.moonAltitudeDeg != null && features.moonAltitudeDeg <= -6;
const moonOk = features.moonIlluminationPct <= 30 || moonBelowHorizon;
```

The -6° threshold is consistent with the evaluator's table where moon alt ≤ -6° yields a moonAltFactor of 0.00 (no moonlight whatsoever).

## Changes

- **`src/domain/scoring/sessions/shared.ts`** — `astroConfidence()` now treats bright moon as non-problematic when `moonAltitudeDeg <= -6`
- **`src/domain/scoring/sessions/index.test.ts`** — New test confirming bright-moon-below-horizon sessions get strictly better confidence than bright-moon-above-horizon sessions

## Impact

- Sessions with 93% moon illumination but moon at -15° altitude: confidence upgrades from `"low"` to `"medium"` or `"high"` (depending on spread)
- No change when moon is above horizon — existing penalty logic preserved
- All 546 tests pass