### PR TITLE
fix: Plan B text strips trailing period and lowercases risk clause

### DIFF
--- a/src/domain/scoring/sessions/index.ts
+++ b/src/domain/scoring/sessions/index.ts
@@ -109,8 +109,9 @@ function buildPlanB(
   if (!primary || !runnerUp) return null;
   if (primary.confidence === 'high') return null;
 
-  const riskClause = primary.warnings[0]
+  const rawRisk = primary.warnings[0]
     || `${sessionLabel(primary.session)} conditions don't hold`;
+  const riskClause = rawRisk.replace(/\.\s*$/, '').replace(/^./, c => c.toLowerCase());
   const reason = runnerUp.reasons[0] || `${sessionLabel(runnerUp.session)} conditions look favourable`;
 
   return `If ${riskClause}: consider ${sessionLabel(runnerUp.session).toLowerCase()} at ${runnerUp.hourLabel} — ${reason.charAt(0).toLowerCase()}${reason.slice(1)}`;


### PR DESCRIPTION
## Problem

`buildPlanB()` interpolated `primary.warnings[0]` verbatim into `If ${riskClause}: consider...`, producing malformed text like:

> If Very few clouds may limit visual interest in longer exposures.: consider wildlife at 20:00...

Two issues:
1. **Double punctuation** — trailing period from the warning + colon = `.:"
2. **Awkward capitalisation** — full-sentence warning after "If" starts with uppercase

## Fix

Strip trailing period from the risk clause and lowercase the first character so it reads as a proper subordinate clause:

> If very few clouds may limit visual interest in longer exposures: consider wildlife at 20:00...

## Testing

73 session scoring tests pass.