### PR TITLE
fix: remove todayDay.bestAlt fallback that bypassed delta filter

### DIFF
--- a/src/presenters/shared/presenter-context.ts
+++ b/src/presenters/shared/presenter-context.ts
@@ -82,7 +82,7 @@ export function buildSharedPresentationContext(
 
   const topPrimaryAlternative = input.altLocations?.[0] || null;
   const topCloseContender = input.closeContenders?.[0] || null;
-  const topAlternative = topPrimaryAlternative || topCloseContender || todayDay.bestAlt || null;
+  const topAlternative = topPrimaryAlternative || topCloseContender || null;
   const topAlternativeIsCloseContender =
     !topPrimaryAlternative &&
     !!topCloseContender &&


### PR DESCRIPTION
## Problem

The `topAlternative` fallback chain in `presenter-context.ts` was:

```ts
topPrimaryAlternative || topCloseContender || todayDay.bestAlt || null
```

`todayDay.bestAlt` comes from `augmentSummary()` which only checks the absolute score threshold (`meetsThreshold`), **not** the 8-point delta (`BEAT_HOME_MARGIN`). When all alternatives were rejected by the delta filter, the hero still showed a 'Best nearby astro alternative' card for a location that didn't qualify.

**Evidence:** Debug trace showed Ribblehead Viaduct rejected ('score does not beat Leeds by at least 8 points: 69 vs 69'), yet the email hero displayed 'Best nearby astro alternative: Ribblehead Viaduct · 69/100'.

## Fix

Remove the `todayDay.bestAlt` fallback. When both `altLocations` and `closeContenders` are empty, `topAlternative` is now `null` and no alternative card is shown.

## Testing

194 presenter tests pass.