### PR TITLE
fix: moonAstroContext qualifies banner when astro windows exist despite bright moon

### DIFF
--- a/src/presenters/email/index.ts
+++ b/src/presenters/email/index.ts
@@ -129,6 +129,7 @@ export function formatEmail(input: FormatEmailInput): string {
     topAlternativeIsCloseContender,
     localSummary,
     spurOfTheMoment,
+    hasAstroWindow: windows.some(w => w.label?.toLowerCase().includes('astro') || (w.tops || []).includes('astrophotography')),
   });
 
   const signals = signalCards(shSunriseQ, shSunsetQ, shSunsetText, sunDir, crepPeak, metarNote, peakKpTonight, auroraSignal, locationName, homeLatitude);

--- a/src/presenters/email/sections/hero.ts
+++ b/src/presenters/email/sections/hero.ts
@@ -40,6 +40,7 @@ export interface HeroSectionParams {
   topAlternativeIsCloseContender: boolean;
   localSummary: string;
   spurOfTheMoment?: SpurOfTheMomentSuggestion | null;
+  hasAstroWindow?: boolean;
 }
 
 export function heroSection(p: HeroSectionParams): string {
@@ -109,7 +110,7 @@ export function heroSection(p: HeroSectionParams): string {
   </table>
   <div style="height:1px;background:rgba(255,255,255,0.10);margin:16px 0;"></div>
   <div style="border-radius:8px;background:rgba(255,255,255,0.07);border:1px solid rgba(255,255,255,0.10);overflow:hidden;">${summaryGrid(factStats, 2)}</div>
-  <div style="Margin-top:5px;padding:0 2px;font-family:${FONT};font-size:11px;color:rgba(255,255,255,0.36);">${moonAstroContext(p.moonPct)}</div>
+  <div style="Margin-top:5px;padding:0 2px;font-family:${FONT};font-size:11px;color:rgba(255,255,255,0.36);">${moonAstroContext(p.moonPct, p.hasAstroWindow)}</div>
   <div style="Margin-top:8px;border-radius:8px;background:rgba(255,255,255,0.07);border:1px solid rgba(255,255,255,0.10);overflow:hidden;">${summaryGrid(scoreStats, 2)}</div>
   ${p.localSummary || alternativeSummary ? '<div style="height:1px;background:rgba(255,255,255,0.10);margin:14px 0 10px;"></div>' : ''}
   ${p.localSummary ? `<div style="font-family:${FONT};font-size:12px;line-height:1.55;color:rgba(255,255,255,0.60);">${esc(p.localSummary.replace(/\n/g, ' · '))}</div>` : ''}

--- a/src/presenters/shared/window-helpers.ts
+++ b/src/presenters/shared/window-helpers.ts
@@ -192,12 +192,15 @@ export function timeAwareLocalSummary(
 
 /**
  * Returns a moon astro context description with icon for the given moon percentage.
+ * When the moon is bright but sets below the horizon during astro windows,
+ * the message is qualified to avoid a blanket "avoid astrophotography" warning.
  */
-export function moonAstroContext(moonPct: number): string {
+export function moonAstroContext(moonPct: number, hasAstroWindow = false): string {
   const icon = moonIconForPct(moonPct);
   if (moonPct <= 15) return `${icon} Dark skies — excellent for astrophotography`;
   if (moonPct <= 40) return `${icon} Low moon glow — good for astrophotography`;
   if (moonPct <= 70) return `${icon} Moderate moon — astrophotography compromised`;
+  if (hasAstroWindow) return `${icon} Bright moon — but sets during late-night astro windows`;
   if (moonPct <= 90) return `${icon} Bright moon — poor for astrophotography`;
   return `${icon} Full moon — avoid astrophotography`;
 }

--- a/src/presenters/site/format-site.ts
+++ b/src/presenters/site/format-site.ts
@@ -163,6 +163,7 @@ export function formatSite(input: FormatEmailInput): string {
     localSummary,
     alternativeSummary,
     altSummaryTitle,
+    hasAstroWindow: windows.some(w => w.label?.toLowerCase().includes('astro') || (w.tops || []).includes('astrophotography')),
   }));
 
   const utilityBar = sDaylightUtilityBar({ todayCarWash: todayCarWashData, runTime });

--- a/src/presenters/site/sections/hero.ts
+++ b/src/presenters/site/sections/hero.ts
@@ -33,6 +33,7 @@ export interface HeroCardProps {
   localSummary: string;
   alternativeSummary: string;
   altSummaryTitle: string;
+  hasAstroWindow?: boolean;
 }
 
 export function sHeroCard(props: HeroCardProps): string {
@@ -83,7 +84,7 @@ export function sHeroCard(props: HeroCardProps): string {
     </div>
     <hr class="hero-divider">
     ${sStatGrid(factStats, 'dark')}
-    <div class="moon-context">${moonAstroContext(moonPct)}</div>
+    <div class="moon-context">${moonAstroContext(moonPct, props.hasAstroWindow)}</div>
     ${sStatGrid(scoreStats, 'dark')}
     ${localSummary || alternativeSummary ? '<hr class="hero-divider" style="margin:12px 0 8px;">' : ''}
     ${localSummary ? `<div style="font-size:12px;line-height:1.55;color:rgba(255,255,255,0.60);">${esc(localSummary.replace(/\n/g, ' · '))}</div>` : ''}


### PR DESCRIPTION
## Problem

After #252 fixed `astroConfidence()` to consider moon altitude, the scoring correctly identifies viable astro windows when a bright moon sets below the horizon. However the presenter-level `moonAstroContext()` still showed a blanket 'Full moon — avoid astrophotography' banner — contradicting what the scoring system actually found.

**Evidence:** Email displayed 'Full moon — avoid astrophotography' even though scoring identified viable late-night astro windows when the moon was below the horizon.

## Fix

Add an optional `hasAstroWindow` parameter to `moonAstroContext()`. When `moonPct > 70` but astro windows exist (implying the moon sets during the night), the banner now reads:

> Bright moon — but sets during late-night astro windows

Both email and site hero sections now derive `hasAstroWindow` from the windows array and pass it through.

## Files changed

- `src/presenters/shared/window-helpers.ts` — `moonAstroContext()` accepts optional `hasAstroWindow`
- `src/presenters/email/sections/hero.ts` — `HeroSectionParams` + call site
- `src/presenters/email/index.ts` — computes `hasAstroWindow` from windows
- `src/presenters/site/sections/hero.ts` — `HeroCardProps` + call site
- `src/presenters/site/format-site.ts` — computes `hasAstroWindow` from windows

## Testing

194 presenter tests pass.