### PR TITLE
fix: dump-pipeline DaySummary type cast, full KP output, and npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest",
     "verify:generated": "node --loader ts-node/esm workflow/build/verify-generated.ts",
     "cli:finalize-brief": "node --loader ts-node/esm src/app/run-photo-brief/finalize-brief-cli.ts",
+    "cli:dump-pipeline": "node --loader ts-node/esm --loader ./scripts/esm-compat-loader.mjs scripts/dump-pipeline.ts",
     "cli:example": "npm run cli:finalize-brief -- ./fixtures/sample-forecast.json"
   },
   "bin": {

--- a/scripts/dump-pipeline.ts
+++ b/scripts/dump-pipeline.ts
@@ -244,7 +244,7 @@ function main() {
     altWeatherData: altWeatherData as any[],
     altLocationMeta: matchedAltMeta,
     homeContext: {
-      dailySummary: scoreResult.dailySummary,
+      dailySummary: scoreResult.dailySummary as any[],
       todayBestScore: scoreResult.todayHours.reduce((max, h) => Math.max(max, h.score), 0),
       debugContext: scoreResult.debugContext,
       windows: scoreResult.debugContext.windows,
@@ -287,7 +287,7 @@ function main() {
     sessionRecommendation: scoreResult.sessionRecommendation,
     metarNote: scoreResult.metarNote,
     aurora: auroraSignal,
-    kpForecast: kpForecast.slice(0, 10), // first few for context
+    kpForecast,
     location: DEFAULT_HOME_LOCATION,
     altLocations: altResult.altLocations,
     closeContenders: altResult.closeContenders,


### PR DESCRIPTION
## Changes

Three fixes to `scripts/dump-pipeline.ts`:

### 1. DaySummary type cast
Added `as any[]` cast for `dailySummary` when building `homeContext` for `scoreAlternatives()`. The `contracts.DaySummary` type lacks the `[key: string]: unknown` index signature present in `score-alternatives/types.DaySummary`, causing a TS2322 error at compile time.

### 2. Full KP forecast output
Removed `.slice(0, 10)` from `kpForecast` in the editorial context output. The debug dump was showing only 10 of 81 KP forecast entries (covering ~27 hours instead of the full ~10-day horizon), hiding G1-G3 storm activity that occurred later in the forecast period.

### 3. npm script
Added `cli:dump-pipeline` to `package.json` matching the invocation documented in `scripts/README.md`.

## Verification

`npm run cli:dump-pipeline` runs successfully, producing all 4 stages. KP data in `03-editorial-context.json` now contains all 81 entries (Mar 29 – Apr 8).