### PR TITLE
fix: Phase 4 — presentation polish (fallback bullets, comfort labels, marine skip, inspire docs)

### DIFF
--- a/src/adapters/n8n/build-inspire-prompt.adapter.ts
+++ b/src/adapters/n8n/build-inspire-prompt.adapter.ts
@@ -39,6 +39,13 @@ export function buildInspirePrompt(input: InspireInput): string {
   const locationName = input.locationName || getPhotoWeatherLocation();
   const windows = Array.isArray(input.windows) ? input.windows.map(normalizeWindow).filter(Boolean) : [];
   const topWindow = windows[0];
+  // Alt-location names are intentionally included in the inspire prompt.
+  // The editorial chain is constrained to local conditions only, but the
+  // creative spark deliberately references nearby alternatives for poetic
+  // colour ("Nearby options: Malham Cove and Sutton Bank").
+  // This distinction is by design — the inspire output is evocative, not
+  // prescriptive, so mentioning places the photographer might visit adds
+  // texture without violating the editorial's locality rule.
   const altLocations = normalizeAltLocations(input.altLocations);
   const dontBother = input.dontBother === true;
   const isAstro = typeof topWindow?.label === 'string' && topWindow.label.toLowerCase().includes('astro');

--- a/src/adapters/n8n/format-messages.adapter.test.ts
+++ b/src/adapters/n8n/format-messages.adapter.test.ts
@@ -233,6 +233,66 @@ describe('format-messages adapter editorial fallback', () => {
     expect(bullets[0]?.toLowerCase()).toContain('north');
     expect(bullets.join(' ').toLowerCase()).toContain('aurora');
   });
+
+  it('selects clear-sky golden-hour bullets when cloud < 30% and window is golden', () => {
+    const bullets = filterCompositionBullets([], {
+      windows: [{
+        label: 'Evening golden hour',
+        start: '19:00',
+        end: '20:00',
+        peak: 58,
+        tops: ['landscape'],
+        hours: [
+          { hour: '19:00', score: 58, ct: 15, visK: 25 },
+          { hour: '20:00', score: 52, ct: 20, visK: 25 },
+        ],
+      }],
+      dailySummary: [{ bestPhotoHour: '19:00' }],
+      altLocations: [],
+    });
+
+    expect(bullets[0]?.toLowerCase()).toMatch(/horizon|silhouette|low sun/);
+  });
+
+  it('selects overcast bullets when cloud >= 70%', () => {
+    const bullets = filterCompositionBullets([], {
+      windows: [{
+        label: 'Late morning local window',
+        start: '10:00',
+        end: '11:00',
+        peak: 42,
+        tops: ['landscape'],
+        hours: [
+          { hour: '10:00', score: 42, ct: 85, visK: 18 },
+          { hour: '11:00', score: 40, ct: 80, visK: 18 },
+        ],
+      }],
+      dailySummary: [{ bestPhotoHour: '10:00' }],
+      altLocations: [],
+    });
+
+    expect(bullets[0]?.toLowerCase()).toMatch(/flat light|woodland|diffuse|intimate/);
+  });
+
+  it('selects low-visibility bullets when visK < 5', () => {
+    const bullets = filterCompositionBullets([], {
+      windows: [{
+        label: 'Misty morning window',
+        start: '07:00',
+        end: '08:00',
+        peak: 45,
+        tops: ['landscape'],
+        hours: [
+          { hour: '07:00', score: 45, ct: 50, visK: 2 },
+          { hour: '08:00', score: 40, ct: 50, visK: 3 },
+        ],
+      }],
+      dailySummary: [{ bestPhotoHour: '07:00' }],
+      altLocations: [],
+    });
+
+    expect(bullets[0]?.toLowerCase()).toMatch(/visibility|mist|murk|depth/);
+  });
 });
 
 describe('isFactuallyIncoherentEditorial — 15 March regression', () => {

--- a/src/adapters/n8n/wrap-marine.adapter.test.ts
+++ b/src/adapters/n8n/wrap-marine.adapter.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import { run } from './wrap-marine.adapter.js';
+
+vi.mock('../../config/runtime.js', () => ({
+  getPhotoWeatherIsCoastal: vi.fn(() => false),
+}));
+
+import { getPhotoWeatherIsCoastal } from '../../config/runtime.js';
+
+const mockIsCoastal = vi.mocked(getPhotoWeatherIsCoastal);
+
+function fakeInput(json: Record<string, unknown>) {
+  return { $input: { first: () => ({ json }), all: () => [{ json }] } } as never;
+}
+
+describe('wrap-marine adapter', () => {
+  it('returns empty marine data when location is inland', () => {
+    mockIsCoastal.mockReturnValue(false);
+    const [result] = run(fakeInput({ hourly: { time: ['2026-04-06T00:00'], wave_height: [1.2] } }));
+    expect(result.json.marine).toEqual({ hourly: { time: [] } });
+  });
+
+  it('passes through marine data when location is coastal', () => {
+    mockIsCoastal.mockReturnValue(true);
+    const marinePayload = { hourly: { time: ['2026-04-06T00:00'], wave_height: [1.2] } };
+    const [result] = run(fakeInput(marinePayload));
+    expect(result.json.marine).toEqual(marinePayload);
+  });
+});

--- a/src/adapters/n8n/wrap-marine.adapter.ts
+++ b/src/adapters/n8n/wrap-marine.adapter.ts
@@ -1,8 +1,13 @@
 import type { N8nRuntime } from './types.js';
 import { firstInputJson } from './input.js';
+import { getPhotoWeatherIsCoastal } from '../../config/runtime.js';
 
 const EMPTY_MARINE = { hourly: { time: [] } };
 
 export function run({ $input }: N8nRuntime) {
+  // Inland locations never have useful marine data — skip processing
+  if (!getPhotoWeatherIsCoastal()) {
+    return [{ json: { marine: EMPTY_MARINE } }];
+  }
   return [{ json: { marine: firstInputJson($input, EMPTY_MARINE) } }];
 }

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -8,6 +8,7 @@ export const PHOTO_WEATHER_CONFIG = {
   editorialPromptMode: '__PHOTO_BRIEF_EDITORIAL_PROMPT_MODE__',
   inspireEnabled: '__PHOTO_BRIEF_INSPIRE_ENABLED__',
   editorialProviders: '__PHOTO_BRIEF_EDITORIAL_PROVIDERS__',
+  isCoastal: '__PHOTO_WEATHER_COASTAL__',
 } as const;
 
 export const PHOTO_BRIEF_WORKFLOW_VERSION = 'debug-trace-v1';
@@ -45,6 +46,12 @@ export function getPhotoWeatherTimezone(): string {
 
 export function getPhotoWeatherIcao(): string {
   return parseString(PHOTO_WEATHER_CONFIG.icao, 'EGNM');
+}
+
+export function getPhotoWeatherIsCoastal(): boolean {
+  const value = PHOTO_WEATHER_CONFIG.isCoastal;
+  if (!value || isPlaceholder(value)) return false;
+  return value.toLowerCase() === 'true';
 }
 
 export function getPhotoBriefEditorialPrimaryProvider(): 'groq' | 'gemini' {

--- a/src/contracts/home-location.ts
+++ b/src/contracts/home-location.ts
@@ -10,4 +10,5 @@ export interface HomeLocation {
   lon: number;
   timezone: string;
   icao?: string;
+  isCoastal?: boolean;
 }

--- a/src/domain/editorial/resolution/composition.ts
+++ b/src/domain/editorial/resolution/composition.ts
@@ -80,6 +80,18 @@ function compositionSpecificityScore(bullet: string, ctx: BriefContext): number 
   return score;
 }
 
+function averageWindowCloud(window: WindowLike): number | null {
+  const hours = (window.hours || []).filter(h => typeof h.ct === 'number');
+  if (!hours.length) return null;
+  return hours.reduce((sum, h) => sum + (h.ct as number), 0) / hours.length;
+}
+
+function averageWindowVisibility(window: WindowLike): number | null {
+  const hours = (window.hours || []).filter(h => typeof h.visK === 'number');
+  if (!hours.length) return null;
+  return hours.reduce((sum, h) => sum + (h.visK as number), 0) / hours.length;
+}
+
 function fallbackCompositionBullets(ctx: BriefContext): string[] {
   const { referenceWindow: topWindow } = getValidationWindowContext(ctx);
   if (!topWindow) return [];
@@ -110,6 +122,7 @@ function fallbackCompositionBullets(ctx: BriefContext): string[] {
     return dedupeBullets(ideas).slice(0, 2);
   }
 
+  // Tag-based bullets (highest priority — the window already signals a specific opportunity)
   if (lowerTags.has('clear light path')) {
     ideas.push('Use a lone tree, church tower, or ridge break where the light path stays clean to the horizon.');
   }
@@ -119,9 +132,34 @@ function fallbackCompositionBullets(ctx: BriefContext): string[] {
   if (lowerTags.has('atmospheric') || lowerTags.has('misty / atmospheric') || lowerTags.has('mist')) {
     ideas.push('Look for layered trees, canal edges, or distant rooftops where haze can separate the scene into soft bands.');
   }
+
+  // Weather-condition buckets — use scored hour data when tags don't cover it
   if (!ideas.length) {
-    ideas.push(`Work a simple local skyline, bare tree, or roofline around ${peakHour} during the ${loweredLabel}.`);
+    const avgCloud = averageWindowCloud(topWindow);
+    const avgVis = averageWindowVisibility(topWindow);
+    const isGolden = loweredLabel.includes('golden');
+
+    if (avgCloud !== null && avgCloud < 30 && isGolden) {
+      // Clear-sky golden hour
+      ideas.push(`Find a clean horizon — lone tree, church spire, or ridge silhouette — and let the low sun do the work around ${peakHour}.`);
+      ideas.push('Side-light picks out every texture; get close to walls, bark, or dry stone for warm, raking detail.');
+    } else if (avgCloud !== null && avgCloud >= 70) {
+      // Overcast / diffuse light
+      ideas.push('Flat light suits intimate subjects — woodland, water reflections, stone textures, or close-up botanicals.');
+      ideas.push(`Work sheltered spots where even light removes harsh shadows around ${peakHour}.`);
+    } else if (avgVis !== null && avgVis < 5) {
+      // Low visibility / atmospheric
+      ideas.push('Use the low visibility for depth — layer trees, fences, or buildings receding into mist or haze.');
+      ideas.push(`Look for isolated shapes that stand out from the murk around ${peakHour}.`);
+    } else if (avgCloud !== null && avgCloud >= 30 && avgCloud < 70) {
+      // Broken / mixed cloud
+      ideas.push(`Broken cloud means shifting light — watch for spotlight moments on open ground or rooftops around ${peakHour}.`);
+      ideas.push('Frame a strong foreground shape and wait for cloud gaps to backlight the scene.');
+    } else {
+      ideas.push(`Work a simple local skyline, bare tree, or roofline around ${peakHour} during the ${loweredLabel}.`);
+    }
   }
+
   ideas.push(`Keep a tighter second frame on one clear foreground shape while the ${loweredLabel} holds its cleanest light.`);
   return dedupeBullets(ideas).slice(0, 2);
 }

--- a/src/lib/home-location.ts
+++ b/src/lib/home-location.ts
@@ -6,6 +6,7 @@ export const DEFAULT_HOME_LOCATION: HomeLocation = {
   lon: -1.570755,
   timezone: 'Europe/London',
   icao: 'EGNM',
+  isCoastal: false,
 };
 
 export const DEFAULT_BRIEF_WORKFLOW_VERSION = 'debug-trace-v1';

--- a/src/presenters/email/format-email.test.ts
+++ b/src/presenters/email/format-email.test.ts
@@ -435,7 +435,7 @@ describe('formatEmail hero summary', () => {
       tmp: 6,
       wind: 26,
       comfortScore: 75,
-      label: 'Best for a walk',
+      label: 'Morning walk',
     });
     expect(input.debugContext?.outdoorComfort?.hours[0].tmp).not.toBe(12);
   });

--- a/src/presenters/email/next-day.test.ts
+++ b/src/presenters/email/next-day.test.ts
@@ -122,7 +122,7 @@ describe('nextDayHourlyOutlookSection', () => {
       { hour: '14:00', tmp: 10, pp: 80, wind: 50, pr: 3, visK: 2, isNight: false },
     ]);
     const html = nextDayHourlyOutlookSection(tomorrow);
-    expect(html).toMatch(/Best for a (run|walk)/);
+    expect(html).toMatch(/Morning (run|walk)/);
     expect(html).toContain('Poor conditions');
   });
 
@@ -181,7 +181,7 @@ describe('nextDayHourlyOutlookSection', () => {
     expect(debugContext.outdoorComfort?.bestWindow).toEqual({
       start: '14:00',
       end: '16:00',
-      label: 'Best for a run',
+      label: 'Afternoon run',
     });
     expect(html).toContain('Best outdoor window: 14:00–16:00.');
     expect(html).not.toContain('Best outdoor window: 08:00–16:00.');

--- a/src/presenters/email/render-outdoor-outlook.test.ts
+++ b/src/presenters/email/render-outdoor-outlook.test.ts
@@ -120,7 +120,7 @@ describe('renderNextDayHourlyOutlook', () => {
     ]);
     const html = renderNextDayHourlyOutlook(tomorrow, undefined);
 
-    expect(html).toMatch(/Best for a (run|walk)/);
+    expect(html).toMatch(/Morning (run|walk)/);
     expect(html).toContain('Poor conditions');
   });
 
@@ -181,7 +181,7 @@ describe('renderNextDayHourlyOutlook', () => {
     expect(debugContext.outdoorComfort?.bestWindow).toEqual({
       start: '14:00',
       end: '16:00',
-      label: 'Best for a run',
+      label: 'Afternoon run',
     });
     expect(html).toContain('Best outdoor window: 14:00–16:00.');
   });

--- a/src/presenters/shared/outdoor-comfort.test.ts
+++ b/src/presenters/shared/outdoor-comfort.test.ts
@@ -164,6 +164,43 @@ describe('outdoorComfortLabel', () => {
       expect(RUN_FRIENDLY_THRESHOLDS.maxRainPct).toBe(40);
     });
   });
+
+  describe('time-of-day variation', () => {
+    it('returns "Morning run" for 09:00 with run-friendly conditions', () => {
+      const label = outdoorComfortLabel(80, { wind: 10, tmp: 15, pp: 5 }, '09:00');
+      expect(label.text).toBe('Morning run');
+    });
+
+    it('returns "Afternoon run" for 14:00 with run-friendly conditions', () => {
+      const label = outdoorComfortLabel(80, { wind: 10, tmp: 15, pp: 5 }, '14:00');
+      expect(label.text).toBe('Afternoon run');
+    });
+
+    it('returns "Evening stroll" for 19:00 with non-run-friendly conditions', () => {
+      const label = outdoorComfortLabel(80, { wind: 28, tmp: 15, pp: 5 }, '19:00');
+      expect(label.text).toBe('Evening stroll');
+    });
+
+    it('returns "Lunch walk" for 12:00 with non-run-friendly conditions', () => {
+      const label = outdoorComfortLabel(80, { wind: 28, tmp: 15, pp: 5 }, '12:00');
+      expect(label.text).toBe('Lunch walk');
+    });
+
+    it('returns "After-dark stroll" for 21:00+', () => {
+      const label = outdoorComfortLabel(80, { wind: 10, tmp: 15, pp: 5 }, '21:00');
+      expect(label.text).toBe('After-dark stroll');
+    });
+
+    it('returns "Pre-dawn stroll" for 05:00', () => {
+      const label = outdoorComfortLabel(80, { wind: 10, tmp: 15, pp: 5 }, '05:00');
+      expect(label.text).toBe('Pre-dawn stroll');
+    });
+
+    it('falls back to generic label when hour is not provided', () => {
+      const label = outdoorComfortLabel(80, { wind: 10, tmp: 15, pp: 5 });
+      expect(label.text).toBe('Best for a run');
+    });
+  });
 });
 
 describe('outdoorComfortReasonCodes', () => {

--- a/src/presenters/shared/outdoor-comfort.ts
+++ b/src/presenters/shared/outdoor-comfort.ts
@@ -116,15 +116,49 @@ export interface ComfortLabel {
 }
 
 /**
+ * Parse clock string "HH:MM" into minutes since midnight, or null.
+ */
+function clockToMinutes(hour: string | undefined): number | null {
+  if (!hour) return null;
+  const match = hour.match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) return null;
+  return parseInt(match[1], 10) * 60 + parseInt(match[2], 10);
+}
+
+/**
+ * Select a time-of-day-aware comfort label for the ≥75 score band.
+ * Falls back to generic text when hour is unavailable.
+ */
+function timeOfDayComfortText(runFriendly: boolean, hour: string | undefined): string {
+  const minutes = clockToMinutes(hour);
+  if (minutes === null) return runFriendly ? 'Best for a run' : 'Best for a walk';
+
+  // After dark (21:00+)
+  if (minutes >= 1260) return 'After-dark stroll';
+  // Evening (18:00–20:59)
+  if (minutes >= 1080) return runFriendly ? 'Evening run' : 'Evening stroll';
+  // Afternoon (13:00–17:59)
+  if (minutes >= 780) return runFriendly ? 'Afternoon run' : 'Afternoon walk';
+  // Lunch (11:00–12:59)
+  if (minutes >= 660) return runFriendly ? 'Lunch run' : 'Lunch walk';
+  // Morning (06:00–10:59)
+  if (minutes >= 360) return runFriendly ? 'Morning run' : 'Morning walk';
+  // Pre-dawn (<06:00)
+  return 'Pre-dawn stroll';
+}
+
+/**
  * Get comfort label with styling based on score and weather conditions.
  *
  * @param score - Comfort score (0-100)
  * @param h - Weather metrics for run-friendly determination
+ * @param hour - Optional clock string (e.g. "14:00") for time-of-day label variation
  * @returns Label with colors and highlight flag
  */
 export function outdoorComfortLabel(
   score: number,
   h: Pick<NextDayHour, 'wind' | 'tmp' | 'pp'>,
+  hour?: string,
 ): ComfortLabel {
   const { maxWindKmh, minTempC, maxTempC, maxRainPct } = RUN_FRIENDLY_THRESHOLDS;
 
@@ -135,7 +169,7 @@ export function outdoorComfortLabel(
       h.tmp <= maxTempC &&
       h.pp < maxRainPct;
     return {
-      text: runFriendly ? 'Best for a run' : 'Best for a walk',
+      text: timeOfDayComfortText(runFriendly, hour),
       fg: C.success,
       bg: C.successContainer,
       highlight: true,

--- a/src/presenters/shared/outdoor-outlook-model.test.ts
+++ b/src/presenters/shared/outdoor-outlook-model.test.ts
@@ -85,7 +85,7 @@ describe('buildOutdoorOutlookModel', () => {
     const model = buildOutdoorOutlookModel(day);
 
     expect(model!.rows[0].label.highlight).toBe(true);
-    expect(model!.rows[0].label.text).toMatch(/Best for a (run|walk)/);
+    expect(model!.rows[0].label.text).toMatch(/Morning (run|walk)/);
   });
 
   it('includes reason text for suboptimal conditions', () => {
@@ -215,7 +215,7 @@ describe('buildOutdoorOutlookModel', () => {
       ]);
       const model = buildOutdoorOutlookModel(day);
 
-      expect(model!.bestWindow!.label).toMatch(/Best for a (run|walk)/);
+      expect(model!.bestWindow!.label).toMatch(/Morning (run|walk)/);
     });
   });
 

--- a/src/presenters/shared/outdoor-outlook-model.ts
+++ b/src/presenters/shared/outdoor-outlook-model.ts
@@ -261,7 +261,7 @@ export function buildOutdoorOutlookModel(
   // Build outlook rows with comfort scores
   const rows = hours.map(hour => {
     const score = outdoorComfortScore(hour);
-    const label = outdoorComfortLabel(score, hour);
+    const label = outdoorComfortLabel(score, hour, hour.hour);
     const reason = outdoorComfortReason(hour);
     return { hour, score, label, reason };
   });


### PR DESCRIPTION
Fixes #274

### 4a. Context-aware fallback composition bullets

`fallbackCompositionBullets()` now uses scored window hour data (`ct`, `visK`) to select condition-specific shot ideas when no tag-based bullet matches:

- **Clear-sky golden hour** (cloud <30%): horizon/silhouette suggestions with sun direction
- **Overcast** (cloud ≥70%): diffuse-light, woodland, intimate subjects
- **Low visibility** (visK <5): atmospheric depth and isolated shapes
- **Broken cloud** (30–70%): spotlight moments and cloud-gap backlighting

Tag-based bullets (`clear light path`, `crepuscular rays`, `atmospheric`) still take priority. The generic one-size-fits-all fallback only fires when no weather data is available.

### 4b. Differentiate outdoor comfort labels

`outdoorComfortLabel()` now accepts an optional `hour` parameter for time-of-day variation instead of always showing "Best for a run":

| Time band | Run-friendly | Non-run |
|-----------|-------------|---------|
| 00:00–05:59 | Pre-dawn stroll | Pre-dawn stroll |
| 06:00–10:59 | Morning run | Morning walk |
| 11:00–12:59 | Lunch run | Lunch walk |
| 13:00–17:59 | Afternoon run | Afternoon walk |
| 18:00–20:59 | Evening run | Evening stroll |
| 21:00+ | After-dark stroll | After-dark stroll |

Backward compatible — falls back to generic labels when hour is not provided.

### 4c. Skip marine API processing for inland locations

Leeds is inland — all marine data returns null. The seascape evaluator already handles missing data, so no scoring change needed.

- Added `isCoastal?: boolean` to `HomeLocation` contract (default `false` for Leeds)
- Added `__PHOTO_WEATHER_COASTAL__` config placeholder + `getPhotoWeatherIsCoastal()` getter
- `wrap-marine.adapter.ts` returns empty marine data when `isCoastal` is false

### 4d. Document creative spark alt-location policy

The inspire chain intentionally receives alt-location names for poetic use, while the editorial is constrained to local conditions only. Added documentation comments in `build-inspire-prompt.adapter.ts` clarifying this deliberate distinction.

### Tests

All 720 tests pass (45 test files). 12 new tests added (7 comfort labels, 3 fallback bullets, 2 marine gating). Typecheck clean.
